### PR TITLE
feat: Change-Service migration + ChangeBlocks UI + themes

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 - Theme-System (MVP): globales Farbschema (`ui_theme_mode`) + Akzentfarbe (`ui_theme_accent`) inkl. Sofortwirkung ohne Neustart. Basis-UI nutzt zentrale Tokens (Background/Surface/Text/Border/Inputs/Buttons/Tables) und Plotly-Layouts werden theming-sensitiv gesetzt. ([#405](https://github.com/thomas682/HA-Addons/issues/405))
 
+## 1.12.452
+
+### Maintenance
+
+- Change-Service Härtung: Schreiboperationen sind jetzt konsequent auf InfluxDB v2 beschraenkt. v1-Schreibpfade (z.B. raw_overwrite/fullrestore) sind deaktiviert, um direkte Influx Writes ausserhalb des Change-Service zu vermeiden. Undo-Status blendet Aktionen mit `undo_supported=false` aus. ([#400](https://github.com/thomas682/HA-Addons/issues/400))
+
 ## 1.12.449
 
 ### Enhancement

--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 - Theme-System (MVP): globales Farbschema (`ui_theme_mode`) + Akzentfarbe (`ui_theme_accent`) inkl. Sofortwirkung ohne Neustart. Basis-UI nutzt zentrale Tokens (Background/Surface/Text/Border/Inputs/Buttons/Tables) und Plotly-Layouts werden theming-sensitiv gesetzt. ([#405](https://github.com/thomas682/HA-Addons/issues/405))
 
+## 1.12.453
+
+### Enhancement
+
+- ChangeBlocks UI: Detailansicht zeigt jetzt ChangeItems (Alt/Neu) und nutzt Preview-Ergebnisse fuer aktuellen DB-Wert (cur/exp) pro Item, inkl. Paging fuer grosse Blocks. Validate liefert dazu `current_value/current_point/expected_value` je Item. ([#404](https://github.com/thomas682/HA-Addons/issues/404))
+
 ## 1.12.452
 
 ### Maintenance

--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -26,6 +26,12 @@
 
 - ChangeBlocks UI: History-Seite zeigt jetzt eine ChangeBlocks-Liste inkl. Detailansicht, Undo/Repeat Preview (validate) und Konfliktanzeige. API `/api/change_block` kann Items optional paginieren (`items_offset/items_limit`). ([#404](https://github.com/thomas682/HA-Addons/issues/404))
 
+## 1.12.451
+
+### Enhancement
+
+- Theme-System (MVP): globales Farbschema (`ui_theme_mode`) + Akzentfarbe (`ui_theme_accent`) inkl. Sofortwirkung ohne Neustart. Basis-UI nutzt zentrale Tokens (Background/Surface/Text/Border/Inputs/Buttons/Tables) und Plotly-Layouts werden theming-sensitiv gesetzt. ([#405](https://github.com/thomas682/HA-Addons/issues/405))
+
 ## 1.12.449
 
 ### Enhancement

--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 - API: neue Endpunkte `/api/change_block/validate`, `/api/change_block/execute`, `/api/change_block/undo`, `/api/change_block/repeat`.
 
+## 1.12.449
+
+### Enhancement
+
+- Change-Service Migration: Bulk- und Range-Schreibpfade laufen jetzt ueber persistente ChangeBlocks (Chunking via `child_blocks`), inkl. Restore/Copy, Combine, Import und Delete. Undo/Repeat nutzt ChangeBlock-Referenzen (ref-only) statt direkte Writes. UI zeigt `change_block_id` bei relevanten Jobs/Aktionen. ([#403](https://github.com/thomas682/HA-Addons/issues/403))
+
 ## 1.12.440
 
 ### Enhancement

--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 - API: neue Endpunkte `/api/change_block/validate`, `/api/change_block/execute`, `/api/change_block/undo`, `/api/change_block/repeat`.
 
+## 1.12.450
+
+### Enhancement
+
+- ChangeBlocks UI: History-Seite zeigt jetzt eine ChangeBlocks-Liste inkl. Detailansicht, Undo/Repeat Preview (validate) und Konfliktanzeige. API `/api/change_block` kann Items optional paginieren (`items_offset/items_limit`). ([#404](https://github.com/thomas682/HA-Addons/issues/404))
+
 ## 1.12.449
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -31129,8 +31129,11 @@ def validate_change_block(block_id: str, *, direction: str) -> dict[str, Any]:
                     "item_id": it.get("item_id"),
                     "op": it.get("op"),
                     "state": "ok",
-                    "identity": it.get("point_identity") if isinstance(it.get("point_identity"), dict) else {},
+                    "identity": _cb_norm_point_identity(it.get("point_identity") if isinstance(it.get("point_identity"), dict) else {}),
                     "policy": "blind",
+                    "expected_value": None,
+                    "current_value": None,
+                    "current_point": None,
                 })
                 continue
 
@@ -31138,19 +31141,34 @@ def validate_change_block(block_id: str, *, direction: str) -> dict[str, Any]:
             st, cur = _cb_fetch_current_point(qapi, cfg, pid)
             if st in ("ambiguous", "type_mismatch"):
                 ok_all = False
-                results.append({"item_id": it.get("item_id"), "state": st, "identity": pid})
+                exp_p = _cb_expected_point_for(d, it)
+                results.append({
+                    "item_id": it.get("item_id"),
+                    "op": it.get("op"),
+                    "state": st,
+                    "policy": "strict",
+                    "identity": _cb_norm_point_identity(pid),
+                    "expected_value": _cb_point_value(exp_p) if isinstance(exp_p, dict) else None,
+                    "current_value": None,
+                    "current_point": None,
+                })
                 continue
             # st ok|missing maps to cur point
             ev = _cb_eval_item_state(d, it, cur)
             state = str(ev.get("state") or "conflict")
             if state not in ("ok", "already_applied"):
                 ok_all = False
+            exp_p = _cb_expected_point_for(d, it)
             results.append({
                 "item_id": it.get("item_id"),
                 "op": it.get("op"),
                 "state": state,
-                "identity": pid,
-                **({"details": ev} if state in ("conflict",) else {}),
+                "policy": "strict",
+                "identity": _cb_norm_point_identity(pid),
+                "expected_value": _cb_point_value(exp_p) if isinstance(exp_p, dict) else None,
+                "current_value": _cb_point_value(cur) if isinstance(cur, dict) else None,
+                "current_point": cur,
+                **({"details": ev} if state in ("conflict", "missing") else {}),
             })
 
     summary = {

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -30928,11 +30928,38 @@ def api_change_block_get():
         return jsonify({"ok": False, "error": "id required"}), 400
     include_items = str(request.args.get("include_items") or "").strip().lower() in ("1", "true", "yes", "on")
     try:
+        items_offset = int(request.args.get("items_offset") or 0)
+    except Exception:
+        items_offset = 0
+    try:
+        items_limit = int(request.args.get("items_limit") or (200 if include_items else 0))
+    except Exception:
+        items_limit = 200 if include_items else 0
+    items_offset = max(0, items_offset)
+    items_limit = max(0, min(5000, items_limit))
+    try:
         b = load_change_block(bid, include_items=include_items)
     except Exception as e:
         return jsonify({"ok": False, "error": str(e) or e.__class__.__name__}), 400
     if not b:
         return jsonify({"ok": False, "error": "not found"}), 404
+
+    # Reduce payload size for large blocks.
+    if include_items:
+        items = b.get("items") if isinstance(b.get("items"), list) else []
+        total = len(items)
+        if items_limit <= 0:
+            b = dict(b)
+            b["items_total"] = total
+            b["items_offset"] = items_offset
+            b["items_limit"] = 0
+            b["items"] = []
+        else:
+            b = dict(b)
+            b["items_total"] = total
+            b["items_offset"] = items_offset
+            b["items_limit"] = items_limit
+            b["items"] = items[items_offset : items_offset + items_limit]
     return jsonify({"ok": True, "block": b})
 
 

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -13565,52 +13565,9 @@ def _fullrestore_job_thread(job_id: str, cfg: dict[str, Any], bdir: Path, backup
             flush_child()
             _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "applied": applied, "read_lines": read_lines})
         elif influx_v == 1:
-            c = v1_client(cfg)
-            try:
-                try:
-                    c.switch_database(cfg.get("database"))
-                except Exception:
-                    pass
-
-                batch: list[str] = []
-                with _open_backup_lp_text(bdir, backup_id, is_fullbackup=True) as f:
-                    for line in f:
-                        if is_cancelled():
-                            set_state("cancelled", "Abgebrochen")
-                            raise RuntimeError("cancelled")
-                        s = line.strip("\n")
-                        if not s.strip():
-                            continue
-                        read_lines += 1
-                        batch.append(s)
-                        if len(batch) >= 2000:
-                            c.write_points(
-                                batch,
-                                database=cfg.get("database"),
-                                protocol="line",
-                                time_precision="n",
-                            )
-                            applied += len(batch)
-                            batch = []
-
-                        now = time.monotonic()
-                        if (now - last_tick) >= 0.25:
-                            set_progress(read_lines=read_lines, applied=applied)
-                            last_tick = now
-
-                    if batch:
-                        c.write_points(
-                            batch,
-                            database=cfg.get("database"),
-                            protocol="line",
-                            time_precision="n",
-                        )
-                        applied += len(batch)
-            finally:
-                try:
-                    c.close()
-                except Exception:
-                    pass
+            set_state("error", "Nicht unterstuetzt")
+            set_error("FullRestore wird nur fuer InfluxDB v2 unterstuetzt (Change-Service).")
+            return
 
         set_progress(read_lines=read_lines, applied=applied)
         set_state("done", f"Restored points: {applied}")
@@ -14209,11 +14166,10 @@ def api_fullrestore_job_start():
                 "error": "InfluxDB v2 requires org. Bitte in /config YAML einlesen und speichern.",
             }), 400
     elif influx_v == 1:
-        if not cfg.get("database"):
-            return jsonify({
-                "ok": False,
-                "error": "InfluxDB v1 requires database. Bitte in Einstellungen konfigurieren.",
-            }), 400
+        return jsonify({
+            "ok": False,
+            "error": "FullRestore ist nur fuer InfluxDB v2 unterstuetzt (Change-Service).",
+        }), 400
     else:
         return jsonify({"ok": False, "error": f"unsupported influx_version: {influx_v}"}), 400
 
@@ -23597,6 +23553,8 @@ from(bucket: "{cfg['bucket']}")
 @app.post("/api/raw_overwrite")
 def api_raw_overwrite():
     cfg = _overlay_from_yaml_if_enabled(load_cfg())
+    if int(cfg.get("influx_version", 2) or 2) != 2:
+        return jsonify({"ok": False, "error": "Schreiboperationen sind nur fuer InfluxDB v2 unterstuetzt (Change-Service)."}), 400
     body = request.get_json(force=True) or {}
     measurement = str(body.get("measurement") or "").strip()
     field = str(body.get("field") or "").strip()
@@ -23623,7 +23581,7 @@ def api_raw_overwrite():
     try:
         block_id = ""
         undo_tags: dict[str, str] = {}
-        if int(cfg.get("influx_version", 2)) == 2:
+        if True:
             extra = flux_tag_filter(entity_id, friendly_name)
             start = _dt_to_rfc3339_utc(ts - timedelta(seconds=1))
             stop = _dt_to_rfc3339_utc(ts + timedelta(seconds=1))
@@ -23768,59 +23726,7 @@ def api_raw_overwrite():
                 # Use normalized values for history/undo
                 time_str = time_eff
                 old_value = old_f
-        else:
-            start = _dt_to_rfc3339_utc(ts - timedelta(seconds=1))
-            stop = _dt_to_rfc3339_utc(ts + timedelta(seconds=1))
-            tag_where = influxql_tag_filter(entity_id, friendly_name)
-            q = f'SELECT "{field}" FROM "{measurement}" WHERE time >= \'{start}\' AND time <= \'{stop}\'{tag_where} ORDER BY time ASC LIMIT 5'
-            c = v1_client(cfg)
-            try:
-                res = c.query(q)
-                existing = []
-                for _, pts in res.items():
-                    existing.extend(pts)
-                if not existing:
-                    return jsonify({"ok": False, "error": "Zeitpunkt nicht in DB gefunden"}), 404
-
-                try:
-                    if old_value is None:
-                        # best-effort: use first point
-                        first = existing[0]
-                        old_value = first.get(field) if isinstance(first, dict) else old_value
-                except Exception:
-                    pass
-
-                # Outlier rule guardrails (can be overridden via force=true)
-                try:
-                    chk = _check_outlier_edit_rules(cfg, measurement, field, entity_id, friendly_name, ts, new_value, unit)
-                    viol = chk.get("violations") or []
-                    if viol and not force:
-                        return (
-                            jsonify({
-                                "ok": False,
-                                "error": "Outlier-Regel verletzt. Schreiben blockiert.",
-                                "violations": viol,
-                                "meta": chk.get("meta") or {},
-                                "can_force": True,
-                            }),
-                            409,
-                        )
-                except Exception:
-                    pass
-                tags = {}
-                if entity_id:
-                    tags["entity_id"] = entity_id
-                if friendly_name:
-                    tags["friendly_name"] = friendly_name
-                json_body = {"measurement": measurement, "tags": tags, "time": _dt_to_rfc3339_utc(ts), "fields": {field: new_value}}
-                c.write_points([json_body])
-            finally:
-                try:
-                    c.close()
-                except Exception:
-                    pass
-
-            undo_tags = dict(tags)
+        # v1 write path removed: only InfluxDB v2 is supported for writes.
         _history_append({
             "kind": "change",
             "series": {
@@ -33574,6 +33480,8 @@ from(bucket: "{cfg["bucket"]}")
 @app.post("/api/delete")
 def delete():
     cfg = _overlay_from_yaml_if_enabled(load_cfg())
+    if int(cfg.get("influx_version", 2) or 2) != 2:
+        return jsonify({"ok": False, "error": "Schreiboperationen sind nur fuer InfluxDB v2 unterstuetzt (Change-Service)."}), 400
     body = request.get_json(force=True) or {}
     measurement = body.get("measurement", "")
     field = body.get("field", "")

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -10130,7 +10130,6 @@ from(bucket: "{raw_bucket}")
     lines = []
     with v2_client(cfg) as c:
         qapi = c.query_api()
-        wapi = c.write_api(write_options=SYNCHRONOUS) if not dry_run else None
         series_rows: dict[tuple[str, str, str, str], list[Any]] = {}
         for rec in qapi.query_stream(q, org=cfg["org"]):
             vals = getattr(rec, "values", {}) or {}
@@ -10142,7 +10141,7 @@ from(bucket: "{raw_bucket}")
                 continue
             summary["series"] += 1
             last_valid = None
-            write_batch = []
+            write_items: list[dict[str, Any]] = []
             for rec in recs:
                 summary["points"] += 1
                 dt = rec.get_time()
@@ -10193,16 +10192,62 @@ from(bucket: "{raw_bucket}")
                     if out_val != raw_val:
                         summary["corrected"] += 1
                 last_valid = out_val
-                if not dry_run and wapi is not None and isinstance(dt, datetime):
-                    p = Point(str(measurement)).field(str(field), out_val).time(dt, WritePrecision.NS)
+                if not dry_run and isinstance(dt, datetime):
+                    ts = _dt_to_rfc3339_utc_full(dt.astimezone(timezone.utc))
+                    tags: dict[str, str] = {}
                     if entity_id:
-                        p = p.tag("entity_id", entity_id)
+                        tags["entity_id"] = str(entity_id)
                     if friendly_name:
-                        p = p.tag("friendly_name", friendly_name)
-                    write_batch.append(p)
-            if write_batch and not dry_run and wapi is not None:
-                wapi.write(bucket=clean_bucket, org=cfg["org"], record=write_batch, write_precision=WritePrecision.NS)
-                summary["written"] += len(write_batch)
+                        tags["friendly_name"] = str(friendly_name)
+                    row = {
+                        "_time": ts,
+                        "_measurement": str(measurement),
+                        "_field": str(field),
+                        "_value": out_val,
+                        **tags,
+                    }
+                    pid = {
+                        "bucket": clean_bucket,
+                        "org": str(cfg.get("org") or ""),
+                        "measurement": str(measurement),
+                        "field": str(field),
+                        "timestamp": ts,
+                        "tag_set": tags,
+                    }
+                    write_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "update",
+                        "point_identity": pid,
+                        "old_point": None,
+                        "new_point": row,
+                        "conflict_policy": "blind",
+                    })
+
+            if write_items and not dry_run:
+                bid = uuid.uuid4().hex
+                cb = {
+                    "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                    "block_id": bid,
+                    "created_at": _utc_now_iso_ms(),
+                    "source": {"user_id": None, "ip": None, "ua": None, "trigger_page": "quality", "trigger_source": "cleanup", "trigger_action": "apply", "trigger_button": None},
+                    "operation_source": "quality_cleanup",
+                    "reason": "quality_cleanup",
+                    "status": "created",
+                    "undo_status": "not_run",
+                    "repeat_status": "not_run",
+                    "affected_count": len(write_items),
+                    "series_summary": {"measurement": measurement, "field": field, "entity_id": entity_id, "friendly_name": friendly_name},
+                    "meta": {"raw_bucket": raw_bucket, "clean_bucket": clean_bucket, "undo_supported": False},
+                }
+                save_change_block(cb, items=write_items)
+                out = execute_change_block(bid)
+                if out.get("ok"):
+                    try:
+                        summary["written"] += int(out.get("applied") or 0)
+                    except Exception:
+                        pass
             lines.append({"measurement": measurement, "field": field, "entity_id": entity_id, "friendly_name": friendly_name, "points": len(recs)})
     try:
         QUALITY_CLEANUP_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -13100,6 +13145,7 @@ def _fullrestore_job_public(job: dict[str, Any]) -> dict[str, Any]:
         "message": job.get("message"),
         "started_at": job.get("started_at"),
         "elapsed": _job_elapsed_hms(job),
+        "change_block_id": job.get("change_block_id"),
         "format": str(job.get("format") or "lp"),
         "target_bucket": job.get("target_bucket"),
         "overwrite": bool(job.get("overwrite")),
@@ -13138,6 +13184,12 @@ def _fullrestore_job_thread(job_id: str, cfg: dict[str, Any], bdir: Path, backup
                 return
             for k, v in kw.items():
                 j[k] = v
+
+    # Allow fullrestore to attach a persisted ChangeBlock id.
+    try:
+        set_progress(change_block_id=None)
+    except Exception:
+        pass
 
     def is_cancelled() -> bool:
         with FULLRESTORE_LOCK:
@@ -13403,42 +13455,109 @@ def _fullrestore_job_thread(job_id: str, cfg: dict[str, Any], bdir: Path, backup
 
     try:
         if influx_v == 2:
-            with v2_client(cfg) as c:
-                wapi = c.write_api(write_options=SYNCHRONOUS)
-                batch: list[str] = []
-                with _open_backup_lp_text(bdir, backup_id, is_fullbackup=True) as f:
-                    for line in f:
-                        if is_cancelled():
-                            set_state("cancelled", "Abgebrochen")
-                            raise RuntimeError("cancelled")
-                        s = line.strip("\n")
-                        if not s.strip():
+            parent_id = uuid.uuid4().hex
+            parent = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": parent_id,
+                "created_at": _utc_now_iso_ms(),
+                "source": {"user_id": None, "ip": None, "ua": None, "trigger_page": "restore", "trigger_source": "fullrestore", "trigger_action": "restore", "trigger_button": None},
+                "operation_source": "fullrestore",
+                "reason": f"fullrestore:{backup_id}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": 0,
+                "payload_mode": "inline",
+                "payload_inline": [],
+                "meta": {"child_blocks": [], "undo_supported": False, "backup_id": backup_id},
+            }
+            save_change_block(parent, items=[])
+            try:
+                set_progress(change_block_id=parent_id)
+            except Exception:
+                pass
+
+            child_ids: list[str] = []
+            child_items: list[dict[str, Any]] = []
+            chunk_idx = 0
+
+            def flush_child() -> None:
+                nonlocal chunk_idx, child_items, applied
+                if not child_items:
+                    return
+                cid = uuid.uuid4().hex
+                cb = {
+                    "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                    "block_id": cid,
+                    "created_at": _utc_now_iso_ms(),
+                    "source": parent["source"],
+                    "operation_source": "fullrestore",
+                    "reason": f"fullrestore:{backup_id}#{chunk_idx}",
+                    "status": "created",
+                    "undo_status": "not_run",
+                    "repeat_status": "not_run",
+                    "affected_count": len(child_items),
+                    "meta": {"parent_block_id": parent_id, "chunk_index": chunk_idx, "undo_supported": False},
+                }
+                save_change_block(cb, items=child_items)
+                out = execute_change_block(cid)
+                if not out.get("ok"):
+                    raise RuntimeError("restore conflict")
+                try:
+                    applied += int(out.get("applied") or 0)
+                except Exception:
+                    pass
+                child_ids.append(cid)
+                chunk_idx += 1
+                child_items = []
+                _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+            max_items = 5000
+            with _open_backup_lp_text(bdir, backup_id, is_fullbackup=True) as f:
+                for line in f:
+                    if is_cancelled():
+                        set_state("cancelled", "Abgebrochen")
+                        raise RuntimeError("cancelled")
+                    s = str(line or "").strip("\n")
+                    if not s.strip():
+                        continue
+                    read_lines += 1
+                    pts = _lp_parse_points_from_line(s)
+                    for p in pts:
+                        ts = str(p.get("_time") or "").strip()
+                        meas = str(p.get("_measurement") or "").strip()
+                        fld = str(p.get("_field") or "").strip()
+                        if not ts or not meas or not fld:
                             continue
-                        read_lines += 1
-                        batch.append(s)
-                        if len(batch) >= 2000:
-                            wapi.write(
-                                bucket=cfg["bucket"],
-                                org=cfg["org"],
-                                record=batch,
-                                write_precision=WritePrecision.NS,
-                            )
-                            applied += len(batch)
-                            batch = []
+                        tags = {k: str(v) for k, v in p.items() if k and not str(k).startswith("_") and v is not None}
+                        pid = {
+                            "bucket": str(cfg.get("bucket") or ""),
+                            "org": str(cfg.get("org") or ""),
+                            "measurement": meas,
+                            "field": fld,
+                            "timestamp": ts,
+                            "tag_set": tags,
+                        }
+                        child_items.append({
+                            "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                            "item_id": uuid.uuid4().hex,
+                            "block_id": "",
+                            "op": "update",
+                            "point_identity": pid,
+                            "old_point": None,
+                            "new_point": p,
+                            "conflict_policy": "blind",
+                        })
+                        if len(child_items) >= max_items:
+                            flush_child()
 
-                        now = time.monotonic()
-                        if (now - last_tick) >= 0.25:
-                            set_progress(read_lines=read_lines, applied=applied)
-                            last_tick = now
+                    now = time.monotonic()
+                    if (now - last_tick) >= 0.25:
+                        set_progress(read_lines=read_lines, applied=applied)
+                        last_tick = now
 
-                    if batch:
-                        wapi.write(
-                            bucket=cfg["bucket"],
-                            org=cfg["org"],
-                            record=batch,
-                            write_precision=WritePrecision.NS,
-                        )
-                        applied += len(batch)
+            flush_child()
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "applied": applied, "read_lines": read_lines})
         elif influx_v == 1:
             c = v1_client(cfg)
             try:
@@ -13553,6 +13672,214 @@ def _lp_format_field_value(v: Any, field_type: str | None) -> str | None:
 
 def _dt_to_ns(dt: datetime) -> int:
     return int(dt.astimezone(timezone.utc).timestamp() * 1_000_000_000)
+
+
+def _lp_unescape(s: str) -> str:
+    """Unescape Influx line protocol keys/tag values (best-effort)."""
+
+    out: list[str] = []
+    esc = False
+    for c in str(s or ""):
+        if esc:
+            out.append(c)
+            esc = False
+            continue
+        if c == "\\":
+            esc = True
+            continue
+        out.append(c)
+    # trailing backslash is dropped (best-effort)
+    return "".join(out)
+
+
+def _lp_split_unescaped(s: str, ch: str) -> list[str]:
+    out: list[str] = []
+    cur: list[str] = []
+    esc = False
+    for c in str(s or ""):
+        if esc:
+            cur.append(c)
+            esc = False
+            continue
+        if c == "\\":
+            esc = True
+            continue
+        if c == ch:
+            out.append("".join(cur))
+            cur = []
+            continue
+        cur.append(c)
+    out.append("".join(cur))
+    return out
+
+
+def _lp_find_unescaped(s: str, ch: str) -> int:
+    esc = False
+    for i, c in enumerate(str(s or "")):
+        if esc:
+            esc = False
+            continue
+        if c == "\\":
+            esc = True
+            continue
+        if c == ch:
+            return i
+    return -1
+
+
+def _ns_to_dt(ns: int) -> datetime:
+    # Avoid float precision loss.
+    sec = int(ns // 1_000_000_000)
+    nsec = int(ns % 1_000_000_000)
+    return datetime.fromtimestamp(sec, tz=timezone.utc).replace(microsecond=int(nsec // 1000))
+
+
+def _lp_split_fieldset(s: str) -> list[str]:
+    """Split a fieldset on commas, respecting quoted strings."""
+
+    out: list[str] = []
+    cur: list[str] = []
+    esc = False
+    in_q = False
+    for c in str(s or ""):
+        if esc:
+            cur.append(c)
+            esc = False
+            continue
+        if c == "\\":
+            esc = True
+            cur.append(c)
+            continue
+        if c == '"':
+            in_q = not in_q
+            cur.append(c)
+            continue
+        if c == "," and not in_q:
+            out.append("".join(cur))
+            cur = []
+            continue
+        cur.append(c)
+    out.append("".join(cur))
+    return out
+
+
+def _lp_parse_field_value(raw: str) -> int | float | bool | str | None:
+    s = str(raw or "")
+    if not s:
+        return None
+    s = s.strip()
+    if not s:
+        return None
+
+    # String field values are double-quoted.
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        inner = s[1:-1]
+        # Unescape backslashes and quotes (best-effort).
+        out: list[str] = []
+        esc = False
+        for c in inner:
+            if esc:
+                out.append(c)
+                esc = False
+            elif c == "\\":
+                esc = True
+            else:
+                out.append(c)
+        return "".join(out)
+
+    lo = s.lower()
+    if lo in ("true", "t"):
+        return True
+    if lo in ("false", "f"):
+        return False
+
+    # integers: 123i
+    if s.endswith("i") and s[:-1].lstrip("-").isdigit():
+        try:
+            return int(s[:-1])
+        except Exception:
+            return None
+    # unsigned ints: 123u (treat as int)
+    if s.endswith("u") and s[:-1].isdigit():
+        try:
+            return int(s[:-1])
+        except Exception:
+            return None
+
+    try:
+        v = float(s)
+        if not math.isfinite(v):
+            return None
+        return v
+    except Exception:
+        return None
+
+
+def _lp_parse_points_from_line(line: str) -> list[dict[str, Any]]:
+    """Parse a (numeric) line protocol line into point dicts.
+
+    Returns one dict per field in the fieldset.
+    """
+
+    s = str(line or "").strip("\r\n")
+    if not s.strip():
+        return []
+
+    j = s.rfind(" ")
+    if j <= 0:
+        return []
+    ts_raw = s[j + 1 :].strip()
+    if not ts_raw.isdigit():
+        return []
+    try:
+        ts_ns = int(ts_raw)
+    except Exception:
+        return []
+
+    rest = s[:j]
+    i = _lp_find_unescaped(rest, " ")
+    if i <= 0:
+        return []
+    mt = rest[:i]
+    fieldset = rest[i + 1 :].strip()
+    if not fieldset:
+        return []
+
+    parts = _lp_split_unescaped(mt, ",")
+    if not parts:
+        return []
+    measurement = _lp_unescape(parts[0])
+
+    tags: dict[str, str] = {}
+    for tok in parts[1:]:
+        kpos = _lp_find_unescaped(tok, "=")
+        if kpos <= 0:
+            continue
+        k = _lp_unescape(tok[:kpos])
+        v = _lp_unescape(tok[kpos + 1 :])
+        if k:
+            tags[k] = v
+
+    dt = _ns_to_dt(ts_ns)
+    time_iso = _dt_to_rfc3339_utc_full(dt)
+
+    out: list[dict[str, Any]] = []
+    for ftok in _lp_split_fieldset(fieldset):
+        epos = _lp_find_unescaped(ftok, "=")
+        if epos <= 0:
+            continue
+        fk = _lp_unescape(ftok[:epos])
+        fv = _lp_parse_field_value(ftok[epos + 1 :])
+        if not fk or fv is None:
+            continue
+        out.append({
+            "_time": time_iso,
+            "_measurement": measurement,
+            "_field": fk,
+            "_value": fv,
+            **tags,
+        })
+    return out
 
 
 @app.get("/api/backup_targets")
@@ -14544,25 +14871,152 @@ def api_backup_restore():
         return jsonify({"ok": False, "error": "backup not found"}), 404
 
     try:
-        with v2_client(cfg) as c:
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-            batch: list[str] = []
-            applied = 0
-            with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
-                for line in f:
-                    line = line.strip("\n")
-                    if not line.strip():
-                        continue
-                    batch.append(line)
-                    if len(batch) >= 2000:
-                        wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                        applied += len(batch)
-                        batch = []
-                if batch:
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                    applied += len(batch)
+        parent_id = uuid.uuid4().hex
+        parent = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": parent_id,
+            "created_at": _utc_now_iso_ms(),
+            "source": {
+                "user_id": None,
+                "ip": _req_ip(),
+                "ua": _req_ua(),
+                "trigger_page": "backups",
+                "trigger_source": "backup_restore",
+                "trigger_action": "restore",
+                "trigger_button": None,
+            },
+            "operation_source": "backup_restore",
+            "reason": f"backup_restore:{backup_id}",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": 0,
+            "payload_mode": "inline",
+            "payload_inline": [],
+            "series_summary": {
+                "measurement": str(meta.get("measurement") or ""),
+                "field": str(meta.get("field") or ""),
+                "entity_id": meta.get("entity_id"),
+                "friendly_name": meta.get("friendly_name"),
+            },
+            "meta": {
+                "backup_id": backup_id,
+                "target": body.get("target"),
+                "child_blocks": [],
+                "undo_supported": False,
+            },
+        }
+        save_change_block(parent, items=[])
 
-        return jsonify({"ok": True, "message": f"Restored points: {applied}", "applied": applied})
+        child_ids: list[str] = []
+        child_items: list[dict[str, Any]] = []
+        chunk_idx = 0
+        applied = 0
+        skipped = 0
+
+        def flush_child() -> None:
+            nonlocal chunk_idx, child_items, applied
+            if not child_items:
+                return
+            cid = uuid.uuid4().hex
+            cb = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": cid,
+                "created_at": _utc_now_iso_ms(),
+                "source": parent["source"],
+                "operation_source": "backup_restore",
+                "reason": f"backup_restore:{backup_id}#{chunk_idx}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": len(child_items),
+                "series_summary": parent.get("series_summary") or {},
+                "meta": {
+                    "parent_block_id": parent_id,
+                    "chunk_index": chunk_idx,
+                    "undo_supported": False,
+                },
+            }
+            save_change_block(cb, items=child_items)
+            out = execute_change_block(cid)
+            if not out.get("ok"):
+                raise RuntimeError("restore conflict")
+            try:
+                applied += int(out.get("applied") or 0)
+            except Exception:
+                pass
+            child_ids.append(cid)
+            chunk_idx += 1
+            child_items = []
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+        max_items = 5000
+        with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
+            for raw in f:
+                pts = _lp_parse_points_from_line(raw)
+                if not pts:
+                    skipped += 1
+                    continue
+                for p in pts:
+                    ts = str(p.get("_time") or "").strip()
+                    meas = str(p.get("_measurement") or "").strip()
+                    fld = str(p.get("_field") or "").strip()
+                    if not ts or not meas or not fld:
+                        skipped += 1
+                        continue
+                    tags = {k: str(v) for k, v in p.items() if k and not str(k).startswith("_") and v is not None}
+                    pid = {
+                        "bucket": str(cfg.get("bucket") or ""),
+                        "org": str(cfg.get("org") or ""),
+                        "measurement": meas,
+                        "field": fld,
+                        "timestamp": ts,
+                        "tag_set": tags,
+                    }
+                    child_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "update",
+                        "point_identity": pid,
+                        "old_point": None,
+                        "new_point": p,
+                        "conflict_policy": "blind",
+                    })
+                    if len(child_items) >= max_items:
+                        flush_child()
+
+        flush_child()
+
+        # Promote child blocks list to the parent block.
+        _cb_patch_block_meta(parent_id, {
+            "child_blocks": list(child_ids),
+            "applied": applied,
+            "skipped": skipped,
+        })
+
+        # Register ref-only Undo entry (undo not supported, but repeat is).
+        try:
+            _undo_mgr(cfg).register_action(
+                action_type="update",
+                bucket=str(cfg.get("bucket") or ""),
+                measurement=str(meta.get("measurement") or "backup"),
+                group_label=f"backup_restore ({applied})",
+                before_rows=[],
+                after_rows=[],
+                meta={"change_block_id": parent_id, "backup_id": backup_id, "undo_supported": False},
+            )
+        except Exception:
+            pass
+
+        return jsonify({
+            "ok": True,
+            "message": f"Restored points: {applied}",
+            "applied": applied,
+            "skipped": skipped,
+            "change_block_id": parent_id,
+            "child_blocks": child_ids,
+        })
     except Exception as e:
         return jsonify({"ok": False, "error": _short_influx_error(e)}), 500
 
@@ -14760,27 +15214,148 @@ def api_backup_copy():
         return f"{new_mt} {new_fieldset} {ts_raw}"
 
     try:
-        with v2_client(cfg) as c:
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-            batch: list[str] = []
-            applied = 0
-            skipped = 0
-            with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
-                for raw in f:
-                    out = _rewrite_line(raw)
-                    if not out:
+        parent_id = uuid.uuid4().hex
+        parent = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": parent_id,
+            "created_at": _utc_now_iso_ms(),
+            "source": {
+                "user_id": None,
+                "ip": _req_ip(),
+                "ua": _req_ua(),
+                "trigger_page": "backups",
+                "trigger_source": "backup_copy",
+                "trigger_action": "copy",
+                "trigger_button": None,
+            },
+            "operation_source": "backup_copy",
+            "reason": f"backup_copy:{backup_id}",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": 0,
+            "payload_mode": "inline",
+            "payload_inline": [],
+            "series_summary": {
+                "measurement": target_measurement,
+                "field": target_field,
+                "entity_id": target_entity_id,
+                "friendly_name": target_friendly_name,
+            },
+            "meta": {
+                "backup_id": backup_id,
+                "child_blocks": [],
+                "undo_supported": False,
+            },
+        }
+        save_change_block(parent, items=[])
+
+        child_ids: list[str] = []
+        child_items: list[dict[str, Any]] = []
+        chunk_idx = 0
+        applied = 0
+        skipped = 0
+
+        def flush_child() -> None:
+            nonlocal chunk_idx, child_items, applied
+            if not child_items:
+                return
+            cid = uuid.uuid4().hex
+            cb = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": cid,
+                "created_at": _utc_now_iso_ms(),
+                "source": parent["source"],
+                "operation_source": "backup_copy",
+                "reason": f"backup_copy:{backup_id}#{chunk_idx}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": len(child_items),
+                "series_summary": parent.get("series_summary") or {},
+                "meta": {
+                    "parent_block_id": parent_id,
+                    "chunk_index": chunk_idx,
+                    "undo_supported": False,
+                },
+            }
+            save_change_block(cb, items=child_items)
+            out = execute_change_block(cid)
+            if not out.get("ok"):
+                raise RuntimeError("copy conflict")
+            try:
+                applied += int(out.get("applied") or 0)
+            except Exception:
+                pass
+            child_ids.append(cid)
+            chunk_idx += 1
+            child_items = []
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+        max_items = 5000
+        with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
+            for raw in f:
+                out = _rewrite_line(raw)
+                if not out:
+                    skipped += 1
+                    continue
+                if preview_limit > 0 and len(preview_lines) < preview_limit:
+                    preview_lines.append(out)
+
+                pts = _lp_parse_points_from_line(out)
+                if not pts:
+                    skipped += 1
+                    continue
+                for p in pts:
+                    ts = str(p.get("_time") or "").strip()
+                    meas = str(p.get("_measurement") or "").strip()
+                    fld = str(p.get("_field") or "").strip()
+                    if not ts or not meas or not fld:
                         skipped += 1
                         continue
-                    if preview_limit > 0 and len(preview_lines) < preview_limit:
-                        preview_lines.append(out)
-                    batch.append(out)
-                    if len(batch) >= 2000:
-                        wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                        applied += len(batch)
-                        batch = []
-                if batch:
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                    applied += len(batch)
+                    tags = {k: str(v) for k, v in p.items() if k and not str(k).startswith("_") and v is not None}
+                    pid = {
+                        "bucket": str(cfg.get("bucket") or ""),
+                        "org": str(cfg.get("org") or ""),
+                        "measurement": meas,
+                        "field": fld,
+                        "timestamp": ts,
+                        "tag_set": tags,
+                    }
+                    child_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "update",
+                        "point_identity": pid,
+                        "old_point": None,
+                        "new_point": p,
+                        "conflict_policy": "blind",
+                    })
+                    if len(child_items) >= max_items:
+                        flush_child()
+
+        flush_child()
+        _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "applied": applied, "skipped": skipped})
+
+        try:
+            _undo_mgr(cfg).register_action(
+                action_type="update",
+                bucket=str(cfg.get("bucket") or ""),
+                measurement=str(target_measurement or "backup"),
+                group_label=f"backup_copy ({applied})",
+                before_rows=[],
+                after_rows=[],
+                meta={
+                    "change_block_id": parent_id,
+                    "backup_id": backup_id,
+                    "undo_supported": False,
+                    "target_measurement": target_measurement,
+                    "target_field": target_field,
+                },
+            )
+        except Exception:
+            pass
 
         return jsonify({
             "ok": True,
@@ -14789,6 +15364,8 @@ def api_backup_copy():
             "skipped": skipped,
             "preview_limit": preview_limit,
             "preview_lines": preview_lines,
+            "change_block_id": parent_id,
+            "child_blocks": child_ids,
         })
     except Exception as e:
         return jsonify({"ok": False, "error": _short_influx_error(e)}), 500
@@ -14806,6 +15383,7 @@ def _restore_copy_job_public(job: dict[str, Any]) -> dict[str, Any]:
         "message": job.get("message"),
         "started_at": job.get("started_at"),
         "elapsed": _job_elapsed_hms(job),
+        "change_block_id": job.get("change_block_id"),
         "applied": int(job.get("applied") or 0),
         "skipped": int(job.get("skipped") or 0),
         "read_bytes": read_b,
@@ -15019,16 +15597,82 @@ def _restore_copy_job_thread(
     last_tick = time.monotonic()
 
     try:
-        with v2_client(cfg) as c:
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-            set_state("running", "Lese Backup...")
-            with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
-                for raw in f:
-                    with RESTORE_COPY_LOCK:
-                        j = RESTORE_COPY_JOBS.get(job_id) or {}
-                        if bool(j.get("cancelled")):
-                            set_state("cancelled", "Abgebrochen")
-                            return
+        parent_id = uuid.uuid4().hex
+        parent = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": parent_id,
+            "created_at": _utc_now_iso_ms(),
+            "source": {"user_id": None, "ip": None, "ua": None, "trigger_page": "restore", "trigger_source": "restore_copy_job", "trigger_action": "copy", "trigger_button": None},
+            "operation_source": "restore_copy_job",
+            "reason": f"restore_copy_job:{backup_id}",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": 0,
+            "payload_mode": "inline",
+            "payload_inline": [],
+            "series_summary": {
+                "measurement": target_measurement,
+                "field": target_field,
+                "entity_id": target_entity_id,
+                "friendly_name": target_friendly_name,
+            },
+            "meta": {"child_blocks": [], "undo_supported": False, "backup_id": backup_id},
+        }
+        save_change_block(parent, items=[])
+        with RESTORE_COPY_LOCK:
+            if job_id in RESTORE_COPY_JOBS:
+                RESTORE_COPY_JOBS[job_id]["change_block_id"] = parent_id
+
+        child_ids: list[str] = []
+        child_items: list[dict[str, Any]] = []
+        chunk_idx = 0
+        last_ts_ns_in_chunk: int | None = None
+
+        def flush_child() -> None:
+            nonlocal chunk_idx, child_items, applied, last_written_time_ms, last_ts_ns_in_chunk
+            if not child_items:
+                return
+            cid = uuid.uuid4().hex
+            cb = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": cid,
+                "created_at": _utc_now_iso_ms(),
+                "source": parent["source"],
+                "operation_source": "restore_copy_job",
+                "reason": f"restore_copy_job:{backup_id}#{chunk_idx}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": len(child_items),
+                "series_summary": parent.get("series_summary") or {},
+                "meta": {"parent_block_id": parent_id, "chunk_index": chunk_idx, "undo_supported": False},
+            }
+            save_change_block(cb, items=child_items)
+            out = execute_change_block(cid)
+            if not out.get("ok"):
+                raise RuntimeError("copy conflict")
+            try:
+                applied += int(out.get("applied") or 0)
+            except Exception:
+                pass
+            if last_ts_ns_in_chunk is not None:
+                last_written_time_ms = int(last_ts_ns_in_chunk // 1_000_000)
+            child_ids.append(cid)
+            chunk_idx += 1
+            child_items = []
+            last_ts_ns_in_chunk = None
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+        max_items = 5000
+        set_state("running", "Lese Backup...")
+        with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
+            for raw in f:
+                with RESTORE_COPY_LOCK:
+                    j = RESTORE_COPY_JOBS.get(job_id) or {}
+                    if bool(j.get("cancelled")):
+                        set_state("cancelled", "Abgebrochen")
+                        return
 
                     try:
                         read_bytes += len(raw.encode("utf-8"))
@@ -15047,7 +15691,36 @@ def _restore_copy_job_thread(
                     else:
                         if preview_limit > 0 and len(preview_lines) < preview_limit:
                             preview_lines.append(out)
-                        batch.append(out)
+                        ts2 = _raw_ts_ns(out)
+                        if ts2 is not None:
+                            last_ts_ns_in_chunk = ts2
+
+                        pts = _lp_parse_points_from_line(out)
+                        for p in pts:
+                            ts = str(p.get("_time") or "").strip()
+                            meas = str(p.get("_measurement") or "").strip()
+                            fld = str(p.get("_field") or "").strip()
+                            if not ts or not meas or not fld:
+                                continue
+                            tags = {k: str(v) for k, v in p.items() if k and not str(k).startswith("_") and v is not None}
+                            pid = {
+                                "bucket": str(cfg.get("bucket") or ""),
+                                "org": str(cfg.get("org") or ""),
+                                "measurement": meas,
+                                "field": fld,
+                                "timestamp": ts,
+                                "tag_set": tags,
+                            }
+                            child_items.append({
+                                "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                                "item_id": uuid.uuid4().hex,
+                                "block_id": "",
+                                "op": "update",
+                                "point_identity": pid,
+                                "old_point": None,
+                                "new_point": p,
+                                "conflict_policy": "blind",
+                            })
 
                     now = time.monotonic()
                     if (now - last_tick) >= 0.25:
@@ -15060,20 +15733,9 @@ def _restore_copy_job_thread(
                         )
                         last_tick = now
 
-                    if len(batch) >= 2000:
-                        set_state("running", "Schreibe in InfluxDB...")
-                        wapi.write(
-                            bucket=cfg["bucket"],
-                            org=cfg["org"],
-                            record=batch,
-                            write_precision=WritePrecision.NS,
-                        )
-                        applied += len(batch)
-                        # last point timestamp in the batch
-                        ts_last = _raw_ts_ns(batch[-1])
-                        if ts_last is not None:
-                            last_written_time_ms = int(ts_last // 1_000_000)
-                        batch = []
+                    if len(child_items) >= max_items:
+                        set_state("running", "Schreibe via Change-Service...")
+                        flush_child()
                         set_progress(
                             read_bytes=read_bytes,
                             applied=applied,
@@ -15082,26 +15744,18 @@ def _restore_copy_job_thread(
                             last_written_time_ms=last_written_time_ms,
                         )
 
-                if batch:
-                    set_state("running", "Schreibe in InfluxDB...")
-                    wapi.write(
-                        bucket=cfg["bucket"],
-                        org=cfg["org"],
-                        record=batch,
-                        write_precision=WritePrecision.NS,
-                    )
-                    applied += len(batch)
-                    ts_last = _raw_ts_ns(batch[-1])
-                    if ts_last is not None:
-                        last_written_time_ms = int(ts_last // 1_000_000)
-                    batch = []
-                    set_progress(
-                        read_bytes=read_bytes,
-                        applied=applied,
-                        skipped=skipped,
-                        current_time_ms=current_time_ms,
-                        last_written_time_ms=last_written_time_ms,
-                    )
+            if child_items:
+                set_state("running", "Schreibe via Change-Service...")
+                flush_child()
+                set_progress(
+                    read_bytes=read_bytes,
+                    applied=applied,
+                    skipped=skipped,
+                    current_time_ms=current_time_ms,
+                    last_written_time_ms=last_written_time_ms,
+                )
+
+        _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "applied": applied, "skipped": skipped})
 
         with RESTORE_COPY_LOCK:
             if job_id in RESTORE_COPY_JOBS:
@@ -15300,6 +15954,7 @@ def _combine_job_public(job: dict[str, Any]) -> dict[str, Any]:
         "message": job.get("message"),
         "started_at": job.get("started_at"),
         "elapsed": _job_elapsed_hms(job),
+        "change_block_id": job.get("change_block_id"),
         "read": int(job.get("read") or 0),
         "written": int(job.get("written") or 0),
         "skipped": int(job.get("skipped") or 0),
@@ -15435,27 +16090,135 @@ from(bucket: "{cfg["bucket"]}")
         return
 
     # Optional: delete target range first (destructive).
+    parent_id = uuid.uuid4().hex
+    undo_supported = bool(delete_target_first)
+    parent = {
+        "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+        "block_id": parent_id,
+        "created_at": _utc_now_iso_ms(),
+        "source": {"user_id": None, "ip": None, "ua": None, "trigger_page": "combine", "trigger_source": "combine_job", "trigger_action": "copy", "trigger_button": None},
+        "operation_source": "combine_copy",
+        "reason": "combine_copy",
+        "status": "created",
+        "undo_status": "not_run",
+        "repeat_status": "not_run",
+        "affected_count": 0,
+        "payload_mode": "inline",
+        "payload_inline": [],
+        "series_summary": {"measurement": tgt_m, "field": tgt_f, "entity_id": tgt_eid, "friendly_name": tgt_fn},
+        "meta": {
+            "child_blocks": [],
+            "undo_supported": undo_supported,
+            "backup_id": backup_id,
+            "backup_before": bool(backup_before),
+            "delete_target_first": bool(delete_target_first),
+            "source": {"measurement": src_m, "field": src_f, "entity_id": src_eid, "friendly_name": src_fn},
+            "target": {"measurement": tgt_m, "field": tgt_f, "entity_id": tgt_eid, "friendly_name": tgt_fn},
+            "range": {"start": _dt_to_rfc3339_utc_full(start_dt), "stop": _dt_to_rfc3339_utc_full(stop_dt)},
+        },
+    }
+    save_change_block(parent, items=[])
+    try:
+        set_progress(change_block_id=parent_id)
+    except Exception:
+        pass
+
+    child_ids: list[str] = []
+    chunk_idx = 0
+
+    def exec_child(items: list[dict[str, Any]], *, kind: str) -> int:
+        nonlocal chunk_idx
+        if not items:
+            return 0
+        cid = uuid.uuid4().hex
+        cb = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": cid,
+            "created_at": _utc_now_iso_ms(),
+            "source": parent["source"],
+            "operation_source": "combine_copy",
+            "reason": f"combine_copy:{kind}#{chunk_idx}",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": len(items),
+            "series_summary": parent.get("series_summary") or {},
+            "meta": {"parent_block_id": parent_id, "chunk_index": chunk_idx, "kind": kind, "undo_supported": undo_supported},
+        }
+        save_change_block(cb, items=items)
+        out = execute_change_block(cid)
+        if not out.get("ok"):
+            raise RuntimeError("combine conflict")
+        child_ids.append(cid)
+        chunk_idx += 1
+        _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+        try:
+            return int(out.get("applied") or 0)
+        except Exception:
+            return 0
+
+    max_items = 5000
+
+    # Optional: delete target range first (destructive) via exact deletes.
     try:
         if delete_target_first:
             set_state("running", "Loesche Zielbereich...")
-            predicate = f"_measurement={_flux_str(tgt_m)} AND _field={_flux_str(tgt_f)}"
-            if tgt_eid:
-                predicate += f" AND entity_id={_flux_str(tgt_eid)}"
-            if tgt_fn:
-                predicate += f" AND friendly_name={_flux_str(tgt_fn)}"
+            extra_t = flux_tag_filter(tgt_eid, tgt_fn)
+            q_del = f'''
+from(bucket: "{cfg["bucket"]}")
+  |> range(start: time(v: "{_dt_to_rfc3339_utc_full(start_dt)}"), stop: time(v: "{_dt_to_rfc3339_utc_full(stop_dt)}"))
+  |> filter(fn: (r) => r._measurement == {_flux_str(tgt_m)} and r._field == {_flux_str(tgt_f)}{extra_t})
+  |> group()
+  |> sort(columns: ["_time"])
+'''
+            del_items: list[dict[str, Any]] = []
             with v2_client(cfg) as c:
-                c.delete_api().delete(start=start_dt, stop=stop_dt, predicate=predicate, bucket=cfg["bucket"], org=cfg["org"])
+                qapi = c.query_api()
+                for rec in qapi.query_stream(q_del, org=cfg["org"]):
+                    if is_cancelled():
+                        set_state("cancelled", "Abgebrochen")
+                        return
+                    t = rec.get_time()
+                    v = rec.get_value()
+                    if not isinstance(t, datetime):
+                        continue
+                    tags: dict[str, str] = {}
+                    for k, tv in (rec.values or {}).items():
+                        if k in ("result", "table"):
+                            continue
+                        if str(k).startswith("_"):
+                            continue
+                        if tv is None:
+                            continue
+                        tags[str(k)] = str(tv)
+                    ts = _dt_to_rfc3339_utc_full(t.astimezone(timezone.utc))
+                    pid = {"bucket": str(cfg.get("bucket") or ""), "org": str(cfg.get("org") or ""), "measurement": tgt_m, "field": tgt_f, "timestamp": ts, "tag_set": tags}
+                    old_row = {"_time": ts, "_measurement": tgt_m, "_field": tgt_f, "_value": v, **tags}
+                    del_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "delete",
+                        "point_identity": pid,
+                        "old_point": old_row,
+                        "new_point": None,
+                        "conflict_policy": "blind",
+                    })
+                    if len(del_items) >= max_items:
+                        exec_child(del_items, kind="delete")
+                        del_items = []
+            exec_child(del_items, kind="delete")
     except Exception as e:
         set_error(f"delete_target_first failed: {_short_influx_error(e)}")
         set_state("error", "Fehler")
         return
 
+    # Copy as ChangeBlocks writes.
     try:
         with v2_client(cfg) as c:
             qapi = c.query_api()
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-
-            batch: list[Point] = []
+            op_write = "create" if delete_target_first else "update"
+            wr_items: list[dict[str, Any]] = []
             for rec in qapi.query_stream(q, org=cfg["org"]):
                 if is_cancelled():
                     set_state("cancelled", "Abgebrochen")
@@ -15467,38 +16230,42 @@ from(bucket: "{cfg["bucket"]}")
                     if not isinstance(ts, datetime):
                         skipped += 1
                         continue
-                    if isinstance(val, bool) or not isinstance(val, (int, float)):
+                    if val is None:
                         skipped += 1
                         continue
 
-                    p = Point(tgt_m)
-
-                    # Preserve tags from source row (best-effort), then override entity_id/friendly_name.
-                    try:
-                        for k, tv in (rec.values or {}).items():
-                            if k in ("result", "table"):
-                                continue
-                            if str(k).startswith("_"):
-                                continue
-                            if tv is None:
-                                continue
-                            # keep as tag
-                            p = p.tag(str(k), str(tv))
-                    except Exception:
-                        pass
-
+                    tags: dict[str, str] = {}
+                    for k, tv in (rec.values or {}).items():
+                        if k in ("result", "table"):
+                            continue
+                        if str(k).startswith("_"):
+                            continue
+                        if tv is None:
+                            continue
+                        tags[str(k)] = str(tv)
                     if tgt_eid:
-                        p = p.tag("entity_id", tgt_eid)
+                        tags["entity_id"] = str(tgt_eid)
                     if tgt_fn:
-                        p = p.tag("friendly_name", tgt_fn)
+                        tags["friendly_name"] = str(tgt_fn)
 
-                    p = p.field(tgt_f, val).time(ts, WritePrecision.NS)
-                    batch.append(p)
-                    if len(batch) >= 2000:
-                        wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch)
-                        written += len(batch)
-                        last_written_time_ms = int(ts.timestamp() * 1000)
-                        batch = []
+                    ts_iso = _dt_to_rfc3339_utc_full(ts.astimezone(timezone.utc))
+                    row = {"_time": ts_iso, "_measurement": tgt_m, "_field": tgt_f, "_value": val, **tags}
+                    pid = {"bucket": str(cfg.get("bucket") or ""), "org": str(cfg.get("org") or ""), "measurement": tgt_m, "field": tgt_f, "timestamp": ts_iso, "tag_set": tags}
+                    wr_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": op_write,
+                        "point_identity": pid,
+                        "old_point": None,
+                        "new_point": row,
+                        "conflict_policy": "blind",
+                    })
+                    last_written_time_ms = int(ts.timestamp() * 1000)
+                    if len(wr_items) >= max_items:
+                        w = exec_child(wr_items, kind="write")
+                        written += w
+                        wr_items = []
                 except Exception:
                     skipped += 1
                     continue
@@ -15506,19 +16273,17 @@ from(bucket: "{cfg["bucket"]}")
                 if read % 1000 == 0:
                     cur_ms = None
                     try:
-                        if isinstance(ts, datetime):
-                            cur_ms = int(ts.timestamp() * 1000)
+                        cur_ms = int(ts.timestamp() * 1000) if isinstance(ts, datetime) else None
                     except Exception:
                         cur_ms = None
                     set_progress(read=read, written=written, skipped=skipped, current_time_ms=cur_ms, last_written_time_ms=last_written_time_ms)
                     set_state("running", f"Kopiere... {read}")
 
-            if batch:
-                try:
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch)
-                    written += len(batch)
-                except Exception:
-                    pass
+            if wr_items:
+                w = exec_child(wr_items, kind="write")
+                written += w
+
+        _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "read": read, "written": written, "skipped": skipped})
 
         set_progress(read=read, written=written, skipped=skipped, last_written_time_ms=last_written_time_ms)
 
@@ -15543,9 +16308,23 @@ from(bucket: "{cfg["bucket"]}")
                 "read": read,
                 "written": written,
                 "skipped": skipped,
+                "change_block_id": parent_id,
                 "ip": _req_ip(),
                 "ua": _req_ua(),
             })
+        except Exception:
+            pass
+
+        try:
+            _undo_mgr(cfg).register_action(
+                action_type="update",
+                bucket=str(cfg.get("bucket") or ""),
+                measurement=tgt_m,
+                group_label=f"combine_copy ({written})",
+                before_rows=[],
+                after_rows=[],
+                meta={"change_block_id": parent_id, "undo_supported": undo_supported, "backup_id": backup_id},
+            )
         except Exception:
             pass
 
@@ -22820,18 +23599,19 @@ def api_raw_overwrite():
     except Exception as e:
         return jsonify({"ok": False, "error": f"invalid time: {e}"}), 400
     try:
+        block_id = ""
+        undo_tags: dict[str, str] = {}
         if int(cfg.get("influx_version", 2)) == 2:
             extra = flux_tag_filter(entity_id, friendly_name)
             start = _dt_to_rfc3339_utc(ts - timedelta(seconds=1))
             stop = _dt_to_rfc3339_utc(ts + timedelta(seconds=1))
             q = f'''
-from(bucket: "{cfg['bucket']}")
-  |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
-  |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
-  |> keep(columns: ["_time","_value"])
-  |> sort(columns: ["_time"], desc: false)
-  |> limit(n: 5)
-'''
+ from(bucket: "{cfg['bucket']}")
+   |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
+   |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
+   |> sort(columns: ["_time"], desc: false)
+   |> limit(n: 5)
+ '''
             with v2_client(cfg) as c:
                 tables = c.query_api().query(q, org=cfg["org"])
                 existing = []
@@ -22871,19 +23651,101 @@ from(bucket: "{cfg['bucket']}")
                 except Exception:
                     pass
 
-                wapi = c.write_api(write_options=SYNCHRONOUS)
+                if best_rec is None:
+                    return jsonify({"ok": False, "error": "Zeitpunkt nicht in DB gefunden"}), 404
+
+                dt_eff = best_rec.get_time() if isinstance(best_rec.get_time(), datetime) else ts
+                dt_eff = dt_eff.astimezone(timezone.utc) if isinstance(dt_eff, datetime) else ts.astimezone(timezone.utc)
+                time_eff = _dt_to_rfc3339_utc_full(dt_eff)
+
                 try:
-                    if best_rec is not None and old_value is None:
+                    if old_value is None:
                         old_value = best_rec.get_value()
                 except Exception:
                     pass
-                point = Point(measurement).field(field, new_value).time(ts)
-                if entity_id:
-                    point = point.tag("entity_id", entity_id)
-                if friendly_name:
-                    point = point.tag("friendly_name", friendly_name)
-                wapi.write(cfg["bucket"], cfg["org"], point)
-                wapi.close()
+
+                try:
+                    old_f = float(old_value) if old_value is not None else None
+                except Exception:
+                    old_f = None
+                if old_f is None:
+                    return jsonify({"ok": False, "error": "old_value missing/invalid"}), 400
+
+                # Preserve full tag set from the record.
+                tags: dict[str, str] = {}
+                for k, v in (getattr(best_rec, "values", {}) or {}).items():
+                    if k in ("result", "table"):
+                        continue
+                    if str(k).startswith("_"):
+                        continue
+                    if v is None:
+                        continue
+                    tags[str(k)] = str(v)
+
+                undo_tags = dict(tags)
+
+                block_id = uuid.uuid4().hex
+                pid = {
+                    "bucket": str(cfg.get("bucket") or ""),
+                    "org": str(cfg.get("org") or ""),
+                    "measurement": measurement,
+                    "field": field,
+                    "timestamp": time_eff,
+                    "tag_set": tags,
+                }
+                before_row = {"_time": time_eff, "_measurement": measurement, "_field": field, "_value": old_f, **tags}
+                after_row = {"_time": time_eff, "_measurement": measurement, "_field": field, "_value": float(new_value), **tags}
+
+                cb = {
+                    "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                    "block_id": block_id,
+                    "created_at": _utc_now_iso_ms(),
+                    "source": {
+                        "user_id": None,
+                        "ip": _req_ip(),
+                        "ua": _req_ua(),
+                        "trigger_page": "raw",
+                        "trigger_source": "raw_overwrite",
+                        "trigger_action": mode,
+                        "trigger_button": None,
+                    },
+                    "operation_source": "raw_overwrite",
+                    "reason": (f"{mode} [FORCED]" if force else (mode or "manual")),
+                    "status": "created",
+                    "undo_status": "not_run",
+                    "repeat_status": "not_run",
+                    "affected_count": 1,
+                    "series_summary": {
+                        "measurement": measurement,
+                        "field": field,
+                        "entity_id": entity_id,
+                        "friendly_name": friendly_name,
+                    },
+                    "meta": {"mode": mode, "forced": bool(force)},
+                }
+
+                save_change_block(
+                    cb,
+                    items=[
+                        {
+                            "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                            "item_id": uuid.uuid4().hex,
+                            "block_id": block_id,
+                            "op": "update",
+                            "point_identity": pid,
+                            "old_point": before_row,
+                            "new_point": after_row,
+                            "conflict_policy": "strict",
+                        }
+                    ],
+                )
+                out = execute_change_block(block_id)
+                if not out.get("ok"):
+                    return jsonify({"ok": False, "error": "conflict", "change_block_id": block_id, "validation": out.get("validation")}), 409
+
+                # Use normalized values for history/undo
+                time_str = time_eff
+                old_value = old_f
         else:
             start = _dt_to_rfc3339_utc(ts - timedelta(seconds=1))
             stop = _dt_to_rfc3339_utc(ts + timedelta(seconds=1))
@@ -22935,6 +23797,8 @@ from(bucket: "{cfg['bucket']}")
                     c.close()
                 except Exception:
                     pass
+
+            undo_tags = dict(tags)
         _history_append({
             "kind": "change",
             "series": {
@@ -22949,19 +23813,19 @@ from(bucket: "{cfg['bucket']}")
             "old_value": old_value,
             "new_value": new_value,
             "reason": (f"{mode} [FORCED]" if force else (mode or "manual")),
+            "change_block_id": (block_id if int(cfg.get("influx_version", 2)) == 2 else ""),
+            "change_block_kind": f"raw_overwrite:{mode}",
+            "change_block_size": 1,
+            "change_block_start": time_str,
+            "change_block_end": time_str,
             "ip": _req_ip(),
             "ua": _req_ua(),
         })
 
         # Register Undo/Repeat entry (best-effort).
         try:
-            tags = {}
-            if entity_id:
-                tags["entity_id"] = entity_id
-            if friendly_name:
-                tags["friendly_name"] = friendly_name
-            before_row = {"_time": time_str, "_measurement": measurement, "_field": field, "_value": old_value, **tags}
-            after_row = {"_time": time_str, "_measurement": measurement, "_field": field, "_value": new_value, **tags}
+            before_row = {"_time": time_str, "_measurement": measurement, "_field": field, "_value": old_value, **(undo_tags or {})}
+            after_row = {"_time": time_str, "_measurement": measurement, "_field": field, "_value": new_value, **(undo_tags or {})}
             _undo_mgr(cfg).register_action(
                 action_type="update",
                 bucket=str(cfg.get("bucket") or ""),
@@ -22969,7 +23833,13 @@ from(bucket: "{cfg['bucket']}")
                 group_label=f"raw_overwrite:{mode}",
                 before_rows=[before_row],
                 after_rows=[after_row],
-                meta={"mode": mode, "entity_id": entity_id, "friendly_name": friendly_name, "field": field},
+                meta={
+                    "mode": mode,
+                    "entity_id": entity_id,
+                    "friendly_name": friendly_name,
+                    "field": field,
+                    **({"change_block_id": block_id} if int(cfg.get("influx_version", 2)) == 2 else {}),
+                },
             )
         except Exception as e:
             LOG.warning("raw_overwrite undo registration failed: %s", str(e) or e.__class__.__name__)
@@ -28790,10 +29660,12 @@ def apply_edits():
             return -1
 
     try:
+        planned: list[dict[str, Any]] = []
+        before_rows: list[dict[str, Any]] = []
+        after_rows: list[dict[str, Any]] = []
+
         with v2_client(cfg) as c:
             qapi = c.query_api()
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-            applied = 0
 
             for e in edits:
                 if not isinstance(e, dict):
@@ -28824,13 +29696,13 @@ def apply_edits():
                 start = _dt_to_rfc3339_utc_full(dt - timedelta(seconds=2))
                 stop = _dt_to_rfc3339_utc_full(dt + timedelta(seconds=2))
                 q = f'''
-from(bucket: "{cfg["bucket"]}")
-  |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
-  |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
-  |> group()
-  |> sort(columns: ["_time"])
-  |> limit(n: 50)
-'''
+ from(bucket: "{cfg["bucket"]}")
+   |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
+   |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
+   |> group()
+   |> sort(columns: ["_time"])
+   |> limit(n: 50)
+ '''
                 log_query("apply_edits find_orig (flux)", q)
                 tables = qapi.query(q, org=cfg["org"])
 
@@ -28889,30 +29761,163 @@ from(bucket: "{cfg["bucket"]}")
                     # Influx tags are strings; coerce here.
                     tags[str(k)] = str(v)
 
-                p = Point(measurement)
-                for tk, tv in tags.items():
-                    p = p.tag(tk, tv)
-                p = p.field(field, new_val).time(dt, WritePrecision.NS)
-                log_details(
-                    "apply_edits write point time=%s orig=%s new=%s tags=%s",
-                    _dt_to_rfc3339_utc_full(dt),
-                    orig_val,
-                    new_val,
-                    ",".join(sorted(tags.keys())),
-                )
-                wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-                applied += 1
+                # Use the actual record timestamp to ensure we edit the existing point.
+                ts_eff = best_rec.get_time() if isinstance(best_rec.get_time(), datetime) else dt
+                ts_eff = ts_eff.astimezone(timezone.utc)
+                time_eff = _dt_to_rfc3339_utc_full(ts_eff)
 
-            try:
-                if applied > 0:
-                    _dash_cache_mark_dirty_series(measurement, field, entity_id, friendly_name, "apply_edits")
-                    _stats_cache_mark_dirty_series(measurement, field, entity_id, friendly_name, "apply_edits")
-                    patch_job_id = _analysis_cache_mark_dirty_series(cfg, measurement, field, entity_id, friendly_name, "apply_edits")
+                # Preserve numeric field type (int vs float)
+                if isinstance(orig_val, int) and not isinstance(orig_val, bool):
+                    old_typed: int | float = int(orig_val)
+                    new_typed: int | float = int(new_val)
                 else:
-                    patch_job_id = None
-            except Exception:
+                    old_typed = float(orig_val)
+                    new_typed = float(new_val)
+
+                before_row = {"_time": time_eff, "_measurement": measurement, "_field": field, "_value": old_typed, **tags}
+                after_row = {"_time": time_eff, "_measurement": measurement, "_field": field, "_value": new_typed, **tags}
+                planned.append({
+                    "time": time_eff,
+                    "tags": tags,
+                    "old_value": old_typed,
+                    "new_value": new_typed,
+                    "before_row": before_row,
+                    "after_row": after_row,
+                    "reason": "apply_edits",
+                })
+                before_rows.append(before_row)
+                after_rows.append(after_row)
+
+        if not planned:
+            return jsonify({"ok": True, "message": "Applied edits: 0", "applied": 0, "patch_job_id": None})
+
+        block_id = uuid.uuid4().hex
+        change_items: list[dict[str, Any]] = []
+        for it in planned:
+            pid = {
+                "bucket": str(cfg.get("bucket") or ""),
+                "org": str(cfg.get("org") or ""),
+                "measurement": measurement,
+                "field": field,
+                "timestamp": str(it.get("time") or ""),
+                "tag_set": it.get("tags") if isinstance(it.get("tags"), dict) else {},
+            }
+            change_items.append({
+                "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                "item_id": uuid.uuid4().hex,
+                "block_id": block_id,
+                "op": "update",
+                "point_identity": pid,
+                "old_point": it.get("before_row"),
+                "new_point": it.get("after_row"),
+                "conflict_policy": "strict",
+            })
+
+        # Compute block range for UI.
+        try:
+            times = [str(it.get("time") or "") for it in planned if str(it.get("time") or "").strip()]
+            block_start = min(times) if times else ""
+            block_end = max(times) if times else ""
+        except Exception:
+            block_start = ""
+            block_end = ""
+
+        cb = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": block_id,
+            "created_at": _utc_now_iso_ms(),
+            "source": {
+                "user_id": None,
+                "ip": _req_ip(),
+                "ua": _req_ua(),
+                "trigger_page": "dashboard",
+                "trigger_source": "apply_edits",
+                "trigger_action": "apply_edits",
+                "trigger_button": None,
+            },
+            "operation_source": "apply_edits",
+            "reason": "apply_edits",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": len(change_items),
+            "series_summary": {
+                "measurement": measurement,
+                "field": field,
+                "entity_id": entity_id,
+                "friendly_name": friendly_name,
+            },
+        }
+
+        save_change_block(cb, items=change_items)
+        out = execute_change_block(block_id)
+        if not out.get("ok"):
+            return jsonify({"ok": False, "error": "conflict", "change_block_id": block_id, "validation": out.get("validation")}), 409
+        applied = int(out.get("applied") or 0)
+
+        # Audit history
+        try:
+            for it in planned:
+                _history_append({
+                    "kind": "change",
+                    "series": {
+                        "measurement": measurement,
+                        "field": field,
+                        "entity_id": entity_id,
+                        "friendly_name": friendly_name,
+                        "tags": it.get("tags") or {},
+                    },
+                    "time": str(it.get("time") or ""),
+                    "action": "overwrite",
+                    "old_value": it.get("old_value"),
+                    "new_value": it.get("new_value"),
+                    "reason": "apply_edits",
+                    "change_block_id": block_id,
+                    "change_block_kind": "apply_edits",
+                    "change_block_size": len(planned),
+                    "change_block_start": block_start,
+                    "change_block_end": block_end,
+                    "trigger_page": "dashboard",
+                    "trigger_source": "apply_edits",
+                    "trigger_action": "apply_edits",
+                    "trigger_button": None,
+                    "ip": _req_ip(),
+                    "ua": _req_ua(),
+                })
+        except Exception as e:
+            LOG.warning("apply_edits history append failed: %s", str(e) or e.__class__.__name__)
+
+        # Undo/Repeat registration (best-effort)
+        try:
+            _undo_mgr(cfg).register_action(
+                action_type="update",
+                bucket=str(cfg.get("bucket") or ""),
+                measurement=measurement,
+                group_label=f"apply_edits ({applied})",
+                before_rows=[r for r in before_rows if isinstance(r, dict)],
+                after_rows=[r for r in after_rows if isinstance(r, dict)],
+                meta={
+                    "field": field,
+                    "entity_id": entity_id,
+                    "friendly_name": friendly_name,
+                    "change_block_id": block_id,
+                    "change_block_kind": "apply_edits",
+                    "change_block_size": len(planned),
+                },
+            )
+        except Exception as e:
+            LOG.warning("apply_edits undo registration failed: %s", str(e) or e.__class__.__name__)
+
+        try:
+            if applied > 0:
+                _dash_cache_mark_dirty_series(measurement, field, entity_id, friendly_name, "apply_edits")
+                _stats_cache_mark_dirty_series(measurement, field, entity_id, friendly_name, "apply_edits")
+                patch_job_id = _analysis_cache_mark_dirty_series(cfg, measurement, field, entity_id, friendly_name, "apply_edits")
+            else:
                 patch_job_id = None
-            return jsonify({"ok": True, "message": f"Applied edits: {applied}", "applied": applied, "patch_job_id": patch_job_id})
+        except Exception:
+            patch_job_id = None
+        return jsonify({"ok": True, "message": f"Applied edits: {applied}", "applied": applied, "patch_job_id": patch_job_id, "change_block_id": block_id})
     except Exception as ex:
         return jsonify({"ok": False, "error": _short_influx_error(ex)}), 500
 
@@ -28970,23 +29975,10 @@ def apply_changes():
 
     extra = flux_tag_filter(entity_id, friendly_name)
 
-    def _pred_escape(v: str) -> str:
-        return (v or "").replace("\\", "\\\\").replace('"', '\\"')
-
-    def _predicate(measurement_s: str, field_s: str, tags: dict[str, str]) -> str:
-        parts = [f'_measurement="{_pred_escape(measurement_s)}"', f'_field="{_pred_escape(field_s)}"']
-        for k, v in (tags or {}).items():
-            if not k:
-                continue
-            parts.append(f'{k}="{_pred_escape(v)}"')
-        return " AND ".join(parts)
-
     planned: list[dict[str, Any]] = []
 
     with v2_client(cfg) as c:
         qapi = c.query_api()
-        wapi = c.write_api(write_options=SYNCHRONOUS)
-        dapi = c.delete_api()
 
         # Preflight everything first to avoid partial apply.
         for ch in changes:
@@ -29142,69 +30134,106 @@ def apply_changes():
                 "reason": reason,
             })
 
-        # Apply with best-effort rollback on failures.
-        applied_rows: list[dict[str, Any]] = []
-        try:
-            for it in planned:
-                action = str(it.get("action") or "")
-                dt = it.get("dt")
-                tags = it.get("tags") or {}
-                if action == "overwrite":
-                    new_val = it.get("new_value")
-                    p = Point(measurement)
-                    for tk, tv in tags.items():
-                        p = p.tag(tk, tv)
-                    p = p.field(field, new_val).time(dt, WritePrecision.NS)
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-                elif action == "delete":
-                    s = _dt_to_rfc3339_utc_ms(dt - timedelta(milliseconds=2))
-                    e = _dt_to_rfc3339_utc_ms(dt + timedelta(milliseconds=2))
-                    pred = _predicate(measurement, field, tags)
-                    dapi.delete(start=s, stop=e, predicate=pred, bucket=cfg["bucket"], org=cfg["org"])
-                else:
-                    raise RuntimeError("invalid action")
-                applied_rows.append(it)
-        except Exception as e:
-            # Best-effort rollback of already applied changes.
-            try:
-                for it in reversed(applied_rows):
-                    action = str(it.get("action") or "")
-                    dt = it.get("dt")
-                    tags = it.get("tags") or {}
-                    if action == "overwrite":
-                        old_val = it.get("old_value")
-                        p = Point(measurement)
-                        for tk, tv in tags.items():
-                            p = p.tag(tk, tv)
-                        p = p.field(field, old_val).time(dt, WritePrecision.NS)
-                        wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-                    elif action == "delete":
-                        old_val = it.get("old_value")
-                        p = Point(measurement)
-                        for tk, tv in tags.items():
-                            p = p.tag(tk, tv)
-                        p = p.field(field, old_val).time(dt, WritePrecision.NS)
-                        wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-            except Exception:
-                pass
-            return jsonify({"ok": False, "error": str(e) or e.__class__.__name__}), 500
+    # Change-Service: persist a ChangeBlock and execute it via the engine.
+    block_id = uuid.uuid4().hex
+    block_kind = str(trigger_button or trigger_action or trigger_source or "").strip()
+    block_reason = ""
+    for it in planned:
+        r = str(it.get("reason") or "").strip()
+        if r:
+            block_reason = r
+            break
+    if not block_reason:
+        block_reason = str(source_action or trigger_action or trigger_source or "apply_changes").strip()
 
-    applied = len(planned)
+    def _op_source() -> str:
+        if (trigger_source or "") == "raw":
+            kinds = {str(it.get("action") or "").strip().lower() for it in planned}
+            if kinds == {"delete"}:
+                return "raw_delete"
+            return "raw_edit"
+        return str(trigger_action or trigger_source or "api").strip() or "api"
+
+    change_items: list[dict[str, Any]] = []
+    for it in planned:
+        act = str(it.get("action") or "").strip().lower()
+        t_raw = str(it.get("time") or "").strip()
+        tags = it.get("tags") if isinstance(it.get("tags"), dict) else {}
+        before_row = it.get("before_row") if isinstance(it.get("before_row"), dict) else None
+        after_row = it.get("after_row") if isinstance(it.get("after_row"), dict) else None
+        if act not in ("overwrite", "delete"):
+            continue
+        op = "update" if act == "overwrite" else "delete"
+        pid = {
+            "bucket": str(cfg.get("bucket") or ""),
+            "org": str(cfg.get("org") or ""),
+            "measurement": measurement,
+            "field": field,
+            "timestamp": t_raw,
+            "tag_set": tags,
+        }
+        change_items.append({
+            "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+            "item_id": uuid.uuid4().hex,
+            "block_id": block_id,
+            "op": op,
+            "point_identity": pid,
+            "old_point": before_row,
+            "new_point": after_row if op == "update" else None,
+            "conflict_policy": "strict",
+        })
+
+    cb = {
+        "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+        "block_id": block_id,
+        "created_at": _utc_now_iso_ms(),
+        "source": {
+            "user_id": None,
+            "ip": _req_ip(),
+            "ua": _req_ua(),
+            "trigger_page": trigger_page,
+            "trigger_source": trigger_source,
+            "trigger_action": trigger_action,
+            "trigger_button": trigger_button,
+        },
+        "operation_source": _op_source(),
+        "reason": block_reason,
+        "status": "created",
+        "undo_status": "not_run",
+        "repeat_status": "not_run",
+        "affected_count": len(change_items),
+        "series_summary": {
+            "measurement": measurement,
+            "field": field,
+            "entity_id": entity_id,
+            "friendly_name": friendly_name,
+        },
+        "meta": {
+            "detected_outlier_type": detected_outlier_type,
+            "strategy_id": strategy_id,
+            "strategy_description": strategy_description,
+            "source_action": source_action,
+            "block_kind": block_kind,
+        },
+    }
+
+    try:
+        save_change_block(cb, items=change_items)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e) or e.__class__.__name__}), 500
+
+    out = execute_change_block(block_id)
+    if not out.get("ok"):
+        return jsonify({"ok": False, "error": "conflict", "change_block_id": block_id, "validation": out.get("validation")}), 409
+
+    applied = int(out.get("applied") or 0)
 
     # Append audit history entries + undo action only after successful full apply.
     try:
         before_rows = [it.get("before_row") for it in planned if isinstance(it.get("before_row"), dict)]
         after_rows = [it.get("after_row") for it in planned if isinstance(it.get("after_row"), dict)]
 
-        smart_btns = {"raw_linear_range", "raw_copy_first_range"}
-        is_smart_block = (
-            (trigger_page or "") == "dashboard"
-            and (trigger_source or "") == "raw"
-            and (trigger_action or "") == "smart_correction"
-            and (trigger_button or "") in smart_btns
-        )
-        block_id = uuid.uuid4().hex if (is_smart_block or applied > 1) else ""
-        block_kind = (trigger_button or trigger_action or trigger_source or "") if block_id else ""
+        # History markers keep existing UI behavior; all changes now always have a ChangeBlock.
         try:
             dts = [it.get("dt") for it in planned if isinstance(it.get("dt"), datetime)]
             if dts:
@@ -29236,17 +30265,11 @@ def apply_changes():
                 "strategy_id": strategy_id or "",
                 "strategy_description": strategy_description or "",
                 "source_action": source_action or "",
-                **(
-                    {
-                        "change_block_id": block_id,
-                        "change_block_kind": block_kind,
-                        "change_block_size": applied,
-                        "change_block_start": block_start,
-                        "change_block_end": block_end,
-                    }
-                    if block_id
-                    else {}
-                ),
+                "change_block_id": block_id,
+                "change_block_kind": block_kind,
+                "change_block_size": len(planned),
+                "change_block_start": block_start,
+                "change_block_end": block_end,
                 "trigger_page": trigger_page,
                 "trigger_source": trigger_source,
                 "trigger_action": trigger_action,
@@ -29279,6 +30302,9 @@ def apply_changes():
                     "field": field,
                     "entity_id": entity_id,
                     "friendly_name": friendly_name,
+                    "change_block_id": block_id,
+                    "change_block_kind": block_kind,
+                    "change_block_size": len(planned),
                 },
             )
         except Exception as e:
@@ -29502,7 +30528,7 @@ def normalize_change_item(item: dict[str, Any]) -> dict[str, Any]:
     new_p = _cb_norm_point(item.get("new_point") if "new_point" in item else None)
     exp_p = _cb_norm_point(item.get("expected_current_point") if "expected_current_point" in item else None)
     pol = str(item.get("conflict_policy") or "strict").strip().lower() or "strict"
-    if pol not in ("strict",):
+    if pol not in ("strict", "blind"):
         pol = "strict"
 
     out = {
@@ -29543,23 +30569,29 @@ def validate_change_item_schema(item: dict[str, Any]) -> None:
 
     old_p = item.get("old_point")
     new_p = item.get("new_point")
+    pol = str(item.get("conflict_policy") or "").strip().lower()
+    if not pol:
+        raise ValueError("conflict_policy required")
+    if pol not in ("strict", "blind"):
+        raise ValueError("conflict_policy invalid")
+
     if op == "create":
         if old_p is not None:
             raise ValueError("create requires old_point=null")
         if new_p is None:
             raise ValueError("create requires new_point")
     if op == "update":
-        if old_p is None or new_p is None:
-            raise ValueError("update requires old_point and new_point")
+        if pol == "strict":
+            if old_p is None or new_p is None:
+                raise ValueError("update requires old_point and new_point")
+        else:
+            if new_p is None:
+                raise ValueError("update requires new_point")
     if op == "delete":
-        if old_p is None:
+        if pol == "strict" and old_p is None:
             raise ValueError("delete requires old_point")
         if new_p is not None:
             raise ValueError("delete requires new_point=null")
-
-    pol = str(item.get("conflict_policy") or "").strip().lower()
-    if not pol:
-        raise ValueError("conflict_policy required")
 
 
 def normalize_change_block(block: dict[str, Any]) -> dict[str, Any]:
@@ -29904,20 +30936,28 @@ def api_change_block_get():
     return jsonify({"ok": True, "block": b})
 
 
-def _cb_point_value(p: dict[str, Any] | None) -> float | int | None:
+def _cb_point_value(p: dict[str, Any] | None) -> int | float | bool | str | None:
     if not isinstance(p, dict):
         return None
     v = p.get("_value")
     if v is None:
         return None
-    if isinstance(v, bool) or not isinstance(v, (int, float)):
-        return None
-    return v
+    if isinstance(v, (int, float)) and not isinstance(v, bool):
+        return v
+    if isinstance(v, bool):
+        return bool(v)
+    if isinstance(v, str):
+        return v
+    if isinstance(v, (bytes, bytearray)):
+        return bytes(v).decode("utf-8", errors="replace")
+    return None
 
 
 def _cb_values_equal(a: Any, b: Any) -> bool:
     if a is None or b is None:
         return a is None and b is None
+    if isinstance(a, bool) and isinstance(b, bool):
+        return bool(a) == bool(b)
     if isinstance(a, bool) or isinstance(b, bool):
         return False
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
@@ -29925,6 +30965,8 @@ def _cb_values_equal(a: Any, b: Any) -> bool:
             return float(a) == float(b)
         except Exception:
             return False
+    if isinstance(a, str) and isinstance(b, str):
+        return a == b
     return False
 
 
@@ -30022,6 +31064,8 @@ def _cb_fetch_current_point(qapi, cfg: dict[str, Any], pid: dict[str, Any]) -> t
     """
 
     pidn = _cb_norm_point_identity(pid)
+    bucket = str(pidn.get("bucket") or cfg.get("bucket") or "")
+    org = str(pidn.get("org") or cfg.get("org") or "")
     measurement = str(pidn.get("measurement") or "")
     field = str(pidn.get("field") or "")
     tags = pidn.get("tag_set") if isinstance(pidn.get("tag_set"), dict) else {}
@@ -30040,14 +31084,14 @@ def _cb_fetch_current_point(qapi, cfg: dict[str, Any], pid: dict[str, Any]) -> t
         extra_pred += f' and r["{str(k)}"] == {_flux_str(str(v))}'
 
     q = f'''
-from(bucket: "{cfg["bucket"]}")
+ from(bucket: "{bucket}")
   |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
   |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra_pred})
   |> group()
   |> sort(columns: ["_time"])
   |> limit(n: 20)
 '''
-    tables = qapi.query(q, org=cfg["org"])
+    tables = qapi.query(q, org=org)
     recs: list[Any] = []
     for t in tables or []:
         for rec in getattr(t, "records", []) or []:
@@ -30080,7 +31124,7 @@ from(bucket: "{cfg["bucket"]}")
         return "missing", None
 
     cur_val = best.get_value()
-    if isinstance(cur_val, bool) or not isinstance(cur_val, (int, float)):
+    if isinstance(cur_val, (dict, list)):
         return "type_mismatch", None
     out = {
         "_time": _dt_to_rfc3339_utc_full(best.get_time().astimezone(timezone.utc)),
@@ -30122,6 +31166,19 @@ def validate_change_block(block_id: str, *, direction: str) -> dict[str, Any]:
                 ok_all = False
                 results.append({"item_id": it.get("item_id"), "state": "conflict", "error": str(e)})
                 continue
+
+            # Blind mode: skip all preflight checks (for bulk operations).
+            pol = str(it.get("conflict_policy") or "").strip().lower()
+            if pol == "blind":
+                results.append({
+                    "item_id": it.get("item_id"),
+                    "op": it.get("op"),
+                    "state": "ok",
+                    "identity": it.get("point_identity") if isinstance(it.get("point_identity"), dict) else {},
+                    "policy": "blind",
+                })
+                continue
+
             pid = it.get("point_identity") if isinstance(it.get("point_identity"), dict) else {}
             st, cur = _cb_fetch_current_point(qapi, cfg, pid)
             if st in ("ambiguous", "type_mismatch"):
@@ -30153,6 +31210,8 @@ def validate_change_block(block_id: str, *, direction: str) -> dict[str, Any]:
 
 def _cb_delete_exact(dapi, cfg: dict[str, Any], pid: dict[str, Any]) -> None:
     pidn = _cb_norm_point_identity(pid)
+    bucket = str(pidn.get("bucket") or cfg.get("bucket") or "")
+    org = str(pidn.get("org") or cfg.get("org") or "")
     measurement = str(pidn.get("measurement") or "")
     field = str(pidn.get("field") or "")
     tags = pidn.get("tag_set") if isinstance(pidn.get("tag_set"), dict) else {}
@@ -30172,11 +31231,13 @@ def _cb_delete_exact(dapi, cfg: dict[str, Any], pid: dict[str, Any]) -> None:
             continue
         parts.append(f'{str(k)}="{_pred_escape(str(v))}"')
     pred = " AND ".join(parts)
-    dapi.delete(start=s, stop=e, predicate=pred, bucket=cfg["bucket"], org=cfg["org"])
+    dapi.delete(start=s, stop=e, predicate=pred, bucket=bucket, org=org)
 
 
 def _cb_write_exact(wapi, cfg: dict[str, Any], pid: dict[str, Any], point: dict[str, Any]) -> None:
     pidn = _cb_norm_point_identity(pid)
+    bucket = str(pidn.get("bucket") or cfg.get("bucket") or "")
+    org = str(pidn.get("org") or cfg.get("org") or "")
     measurement = str(pidn.get("measurement") or "")
     field = str(pidn.get("field") or "")
     tags = pidn.get("tag_set") if isinstance(pidn.get("tag_set"), dict) else {}
@@ -30191,7 +31252,7 @@ def _cb_write_exact(wapi, cfg: dict[str, Any], pid: dict[str, Any], point: dict[
     for tk, tv in (tags or {}).items():
         p = p.tag(str(tk), str(tv))
     p = p.field(field, v).time(dt, WritePrecision.NS)
-    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
+    wapi.write(bucket=bucket, org=org, record=p)
 
 
 def _cb_set_block_status(block_id: str, *, status: str | None = None, undo_status: str | None = None, repeat_status: str | None = None) -> None:
@@ -30214,9 +31275,78 @@ def _cb_set_block_status(block_id: str, *, status: str | None = None, undo_statu
     _cb_atomic_write_text(meta_path, json.dumps(b, ensure_ascii=True, sort_keys=True, indent=2))
 
 
+def _cb_patch_block_meta(block_id: str, patch: dict[str, Any]) -> None:
+    """Best-effort patch of block.meta (keeps payload unchanged)."""
+
+    bid = _cb_require_block_id(block_id)
+    b = load_change_block(bid, include_items=False)
+    if not b:
+        return
+    if not isinstance(patch, dict):
+        return
+    meta = b.get("meta") if isinstance(b.get("meta"), dict) else {}
+    meta2 = dict(meta)
+    for k, v in patch.items():
+        meta2[str(k)] = v
+    b["meta"] = meta2
+    try:
+        validate_change_block_schema(b)
+    except Exception:
+        return
+    meta_path = _cb_meta_path(bid, str(b.get("created_at") or ""))
+    _cb_atomic_write_text(meta_path, json.dumps(b, ensure_ascii=True, sort_keys=True, indent=2))
+
+
 def _cb_apply(block_id: str, *, direction: str) -> dict[str, Any]:
     bid = _cb_require_block_id(block_id)
     d = str(direction or "").strip().lower()
+
+    b_meta = load_change_block(bid, include_items=False)
+    if not b_meta:
+        return {"ok": False, "error": "not found"}
+    bmeta = b_meta.get("meta") if isinstance(b_meta.get("meta"), dict) else {}
+
+    # Group blocks: execute/undo/repeat a list of child blocks.
+    child_blocks = bmeta.get("child_blocks") if isinstance(bmeta.get("child_blocks"), list) else []
+    child_ids = [str(x).strip() for x in child_blocks if str(x).strip()]
+    if child_ids:
+        # Undo may be explicitly disabled for bulk operations.
+        if d == "undo" and bmeta.get("undo_supported") is False:
+            return {"ok": False, "error": "undo_not_supported", "block_id": bid}
+
+        applied_total = 0
+        # execute/repeat in forward order; undo in reverse order
+        seq = child_ids if d in ("execute", "repeat") else list(reversed(child_ids))
+        for cid in seq:
+            out = execute_change_block(cid) if d == "execute" else (undo_change_block(cid) if d == "undo" else repeat_change_block(cid))
+            if not out.get("ok"):
+                return {
+                    "ok": False,
+                    "error": "child_failed",
+                    "block_id": bid,
+                    "child_block_id": cid,
+                    "child_result": out,
+                }
+            try:
+                applied_total += int(out.get("applied") or 0)
+            except Exception:
+                pass
+
+        try:
+            if d == "execute":
+                _cb_set_block_status(bid, status="applied")
+            elif d == "undo":
+                _cb_set_block_status(bid, undo_status="applied")
+            else:
+                _cb_set_block_status(bid, repeat_status="applied")
+        except Exception:
+            pass
+
+        return {"ok": True, "applied": applied_total, "child_blocks": child_ids}
+
+    # Single blocks: respect opt-out for undo/repeat.
+    if d == "undo" and bmeta.get("undo_supported") is False:
+        return {"ok": False, "error": "undo_not_supported", "block_id": bid}
 
     v = validate_change_block(bid, direction=d)
     if not v.get("summary", {}).get("ok"):
@@ -30232,6 +31362,22 @@ def _cb_apply(block_id: str, *, direction: str) -> dict[str, Any]:
     with v2_client(cfg) as c:
         wapi = c.write_api(write_options=SYNCHRONOUS)
         dapi = c.delete_api()
+
+        write_batch: list[Point] = []
+        batch_bucket: str | None = None
+        batch_org: str | None = None
+
+        def flush_writes() -> None:
+            nonlocal write_batch, batch_bucket, batch_org
+            if not write_batch:
+                return
+            bkt = str(batch_bucket or cfg.get("bucket") or "")
+            org = str(batch_org or cfg.get("org") or "")
+            wapi.write(bucket=bkt, org=org, record=write_batch, write_precision=WritePrecision.NS)
+            write_batch = []
+            batch_bucket = None
+            batch_org = None
+
         # Map item_id -> state for skip
         states = {str(r.get("item_id") or ""): str(r.get("state") or "") for r in (v.get("results") or []) if isinstance(r, dict)}
         for it in items:
@@ -30240,14 +31386,45 @@ def _cb_apply(block_id: str, *, direction: str) -> dict[str, Any]:
             iid = str(it.get("item_id") or "")
             if states.get(iid) == "already_applied":
                 continue
+
             pid = it.get("point_identity") if isinstance(it.get("point_identity"), dict) else {}
             mode, tgt = _cb_target_state_for(d, it)
             if mode == "delete":
+                flush_writes()
                 _cb_delete_exact(dapi, cfg, pid)
                 applied += 1
-            else:
-                _cb_write_exact(wapi, cfg, pid, tgt if isinstance(tgt, dict) else {})
-                applied += 1
+                continue
+
+            # write
+            pidn = _cb_norm_point_identity(pid)
+            item_bucket = str(pidn.get("bucket") or cfg.get("bucket") or "")
+            item_org = str(pidn.get("org") or cfg.get("org") or "")
+            dt = _parse_iso_datetime(str(pidn.get("timestamp") or ""))
+            if not isinstance(dt, datetime):
+                raise RuntimeError("invalid timestamp")
+            dt = dt.astimezone(timezone.utc)
+            val = _cb_point_value(tgt if isinstance(tgt, dict) else {})
+            if val is None:
+                raise RuntimeError("unsupported _value type")
+            p = Point(str(pidn.get("measurement") or ""))
+            tags = pidn.get("tag_set") if isinstance(pidn.get("tag_set"), dict) else {}
+            for tk, tv in (tags or {}).items():
+                p = p.tag(str(tk), str(tv))
+            p = p.field(str(pidn.get("field") or ""), val).time(dt, WritePrecision.NS)
+
+            # Keep batch per (bucket, org)
+            if write_batch and (batch_bucket != item_bucket or batch_org != item_org):
+                flush_writes()
+            if batch_bucket is None:
+                batch_bucket = item_bucket
+            if batch_org is None:
+                batch_org = item_org
+            write_batch.append(p)
+            if len(write_batch) >= 2000:
+                flush_writes()
+            applied += 1
+
+        flush_writes()
 
     # best-effort block status update
     try:
@@ -30824,20 +32001,6 @@ from(bucket: "{cfg["bucket"]}")
     return True, v
 
 
-class _UndoApplyError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        mode: str,
-        applied_rows: list[dict[str, Any]],
-        failed_row: dict[str, Any] | None,
-    ):
-        super().__init__(message)
-        self.mode = str(mode or "")
-        self.applied_rows = applied_rows
-        self.failed_row = failed_row
-
-
 def _undo_row_key(row: dict[str, Any]) -> tuple[str, str, str, tuple[tuple[str, str], ...]]:
     measurement = str(row.get("_measurement") or "").strip()
     field = str(row.get("_field") or "").strip()
@@ -30890,48 +32053,8 @@ def _undo_verify_rows(
 
 
 def _undo_apply_rows(cfg: dict[str, Any], rows: list[dict[str, Any]], mode: str) -> list[dict[str, Any]]:
-    if int(cfg.get("influx_version", 2)) != 2:
-        raise RuntimeError("undo currently supports InfluxDB v2 only")
-    if not (cfg.get("token") and cfg.get("org") and cfg.get("bucket")):
-        raise RuntimeError("InfluxDB v2 requires token, org, bucket")
-    with v2_client(cfg) as c:
-        qapi = c.query_api()
-        wapi = c.write_api(write_options=SYNCHRONOUS)
-        dapi = c.delete_api()
-        applied: list[dict[str, Any]] = []
-        for row in rows or []:
-            if not isinstance(row, dict):
-                continue
-            measurement = str(row.get("_measurement") or "").strip()
-            field = str(row.get("_field") or "").strip()
-            time_raw = str(row.get("_time") or "").strip()
-            if not measurement or not field or not time_raw:
-                continue
-            dt = _parse_iso_datetime(time_raw)
-            tags = _undo_row_tags(row)
-            want_val = row.get("_value")
-
-            try:
-                if mode == "delete":
-                    s = _dt_to_rfc3339_utc_ms(dt - timedelta(milliseconds=2))
-                    e = _dt_to_rfc3339_utc_ms(dt + timedelta(milliseconds=2))
-                    pred = _undo_predicate(measurement, field, tags)
-                    dapi.delete(start=s, stop=e, predicate=pred, bucket=cfg["bucket"], org=cfg["org"])
-                elif mode == "write":
-                    if want_val is None:
-                        continue
-                    p = Point(measurement)
-                    for tk, tv in tags.items():
-                        p = p.tag(tk, tv)
-                    p = p.field(field, want_val).time(dt, WritePrecision.NS)
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-                else:
-                    raise RuntimeError("invalid undo apply mode")
-                applied.append(row)
-            except Exception as e:
-                raise _UndoApplyError(f"Undo/Repeat apply failed (mode={mode})", mode, applied, row) from e
-
-        return applied
+    # Deprecated: Undo/Repeat must go through the Change-Service.
+    raise RuntimeError("deprecated: use ChangeBlocks engine")
 
 
 def _undo_execute_action(cfg: dict[str, Any], action: dict[str, Any], direction: str) -> None:
@@ -30943,71 +32066,86 @@ def _undo_execute_action(cfg: dict[str, Any], action: dict[str, Any], direction:
 
     before_rows = action.get("before_rows") if isinstance(action.get("before_rows"), list) else []
     after_rows = action.get("after_rows") if isinstance(action.get("after_rows"), list) else []
-    atype = str(action.get("action_type") or "update")
 
-    # Decide operations.
-    if direction == "undo":
-        if atype == "delete":
-            to_delete: list[dict[str, Any]] = []
-            to_write = [r for r in before_rows if isinstance(r, dict)]
-        elif atype == "insert":
-            to_delete = [r for r in after_rows if isinstance(r, dict)]
-            to_write = []
-        else:  # update/mixed
-            to_delete = [r for r in after_rows if isinstance(r, dict)]
-            to_write = [r for r in before_rows if isinstance(r, dict)]
-    else:  # repeat
-        if atype == "delete":
-            to_delete = [r for r in before_rows if isinstance(r, dict)]
-            to_write = []
-        elif atype == "insert":
-            to_delete = []
-            to_write = [r for r in after_rows if isinstance(r, dict)]
-        else:  # update/mixed
-            to_delete = [r for r in before_rows if isinstance(r, dict)]
-            to_write = [r for r in after_rows if isinstance(r, dict)]
+    meta = action.get("meta") if isinstance(action.get("meta"), dict) else {}
+    bid = str(meta.get("change_block_id") or action.get("change_block_id") or "").strip()
 
-    # Conflict check: verify expected current rows.
-    if int(cfg.get("influx_version", 2)) != 2:
-        raise RuntimeError("undo currently supports InfluxDB v2 only")
-    if not (cfg.get("token") and cfg.get("org") and cfg.get("bucket")):
-        raise RuntimeError("InfluxDB v2 requires token, org, bucket")
-    with v2_client(cfg) as c:
-        qapi = c.query_api()
-        # rows we are about to delete must exist and should match stored value where possible
-        _undo_verify_rows(qapi, cfg, to_delete, must_exist=True, must_match_value=True)
+    # Preferred path: reuse the persisted ChangeBlock created by the write path.
+    if bid:
+        try:
+            if load_change_block(bid, include_items=False):
+                out = undo_change_block(bid) if direction == "undo" else repeat_change_block(bid)
+                if not out.get("ok"):
+                    raise RuntimeError("undo/repeat conflict")
+                return
+        except Exception:
+            # Fall back to synthesizing a block from before/after rows.
+            pass
 
-        # rows we are about to write should not already exist if they are not part of the delete-set
-        delete_keys = {_undo_row_key(r) for r in to_delete if isinstance(r, dict)}
-        write_need_absent = [r for r in to_write if isinstance(r, dict) and _undo_row_key(r) not in delete_keys]
-        if write_need_absent:
-            _undo_verify_rows(qapi, cfg, write_need_absent, must_exist=False, must_match_value=False)
+    if not bid:
+        bid = uuid.uuid4().hex
+        # Persist for future repeats (UndoManager stores `meta`).
+        meta = dict(meta)
+        meta["change_block_id"] = bid
+        action["meta"] = meta
+        action["change_block_id"] = bid
 
-    # Apply with rollback on partial phase failure.
-    deleted_rows: list[dict[str, Any]] = []
-    try:
-        if to_delete:
-            deleted_rows = _undo_apply_rows(cfg, to_delete, mode="delete")
-        if to_write:
-            _undo_apply_rows(cfg, to_write, mode="write")
-    except _UndoApplyError as e:
-        # Best-effort rollback.
-        if e.mode == "delete" and e.applied_rows:
-            try:
-                _undo_apply_rows(cfg, [r for r in e.applied_rows if isinstance(r, dict)], mode="write")
-            except Exception:
-                pass
-        elif e.mode == "write":
-            try:
-                _undo_apply_rows(cfg, [r for r in e.applied_rows if isinstance(r, dict)], mode="delete")
-            except Exception:
-                pass
-            try:
-                if deleted_rows:
-                    _undo_apply_rows(cfg, deleted_rows, mode="write")
-            except Exception:
-                pass
-        raise
+    items: list[dict[str, Any]] = []
+    max_n = min(5000, max(len(before_rows), len(after_rows)))
+    for i in range(max_n):
+        b = before_rows[i] if i < len(before_rows) and isinstance(before_rows[i], dict) else None
+        a = after_rows[i] if i < len(after_rows) and isinstance(after_rows[i], dict) else None
+        row = a if a is not None else b
+        if row is None:
+            continue
+        measurement = str(row.get("_measurement") or "").strip()
+        field = str(row.get("_field") or "").strip()
+        ts = str(row.get("_time") or "").strip()
+        if not measurement or not field or not ts:
+            continue
+        tags = _undo_row_tags(row)
+        op = "update"
+        if b is None and a is not None:
+            op = "create"
+        elif b is not None and a is None:
+            op = "delete"
+
+        pid = {
+            "bucket": str(cfg.get("bucket") or ""),
+            "org": str(cfg.get("org") or ""),
+            "measurement": measurement,
+            "field": field,
+            "timestamp": ts,
+            "tag_set": tags,
+        }
+        items.append({
+            "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+            "item_id": uuid.uuid4().hex,
+            "block_id": bid,
+            "op": op,
+            "point_identity": pid,
+            "old_point": b,
+            "new_point": a,
+            "conflict_policy": "strict",
+        })
+
+    cb = {
+        "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+        "block_id": bid,
+        "created_at": _utc_now_iso_ms(),
+        "source": {"user_id": None, "ip": _req_ip(), "ua": _req_ua(), "trigger_page": "history", "trigger_source": "undo_mgr", "trigger_action": direction},
+        "operation_source": "undo_mgr",
+        "reason": "undo_mgr",
+        "status": "created",
+        "undo_status": "not_run",
+        "repeat_status": "not_run",
+        "affected_count": len(items),
+        "series_summary": {},
+    }
+    save_change_block(cb, items=items)
+    out = undo_change_block(bid) if direction == "undo" else repeat_change_block(bid)
+    if not out.get("ok"):
+        raise RuntimeError("undo/repeat conflict")
 
 
 @app.post("/api/undo/undo")
@@ -31229,159 +32367,114 @@ def api_history_rollback():
     # Rollback newest first
     wanted.sort(key=lambda x: str(x.get("at") or ""), reverse=True)
 
-    if int(cfg.get("influx_version", 2)) != 2:
-        return jsonify({"ok": False, "error": "history rollback currently supports InfluxDB v2 only"}), 400
-    if not (cfg.get("token") and cfg.get("org") and cfg.get("bucket")):
-        return jsonify({
-            "ok": False,
-            "error": "InfluxDB v2 requires token, org, bucket. Bitte in /config YAML einlesen und speichern.",
-        }), 400
+    # Change-Service rollback: build a ChangeBlock representing the original changes,
+    # then undo it via the engine. (No direct writes here.)
+    for it in wanted:
+        if str(it.get("action") or "").strip().lower() == "combine_copy":
+            return jsonify({
+                "ok": False,
+                "error": "combine_copy rollback not supported yet (requires Change-Service bulk support)",
+            }), 400
 
-    def _restore_backup_into_client(c: InfluxDBClient, backup_id: str) -> int:
-        bdir = backup_dir_for_target(cfg, None)
+    block_id = uuid.uuid4().hex
+    change_items: list[dict[str, Any]] = []
+    for it in wanted:
+        action = str(it.get("action") or "").strip().lower()
+        if action not in ("overwrite", "delete"):
+            continue
+        s = it.get("series") if isinstance(it.get("series"), dict) else {}
+        measurement = str(s.get("measurement") or "").strip()
+        field = str(s.get("field") or "").strip()
+        tags = s.get("tags") if isinstance(s.get("tags"), dict) else {}
+        t_raw = str(it.get("time") or "").strip()
+        if not measurement or not field or not t_raw:
+            continue
+        old_val = it.get("old_value")
+        new_val = it.get("new_value")
+        if old_val is None:
+            continue
+
+        before_row = {"_time": t_raw, "_measurement": measurement, "_field": field, "_value": old_val, **tags}
+        after_row = None
+        if action == "overwrite":
+            after_row = {"_time": t_raw, "_measurement": measurement, "_field": field, "_value": new_val, **tags}
+
+        pid = {
+            "bucket": str(cfg.get("bucket") or ""),
+            "org": str(cfg.get("org") or ""),
+            "measurement": measurement,
+            "field": field,
+            "timestamp": t_raw,
+            "tag_set": tags,
+        }
+        change_items.append({
+            "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+            "item_id": uuid.uuid4().hex,
+            "block_id": block_id,
+            "op": "update" if action == "overwrite" else "delete",
+            "point_identity": pid,
+            "old_point": before_row,
+            "new_point": after_row,
+            "conflict_policy": "strict",
+            "meta": {"history_ref_id": str(it.get("id") or "")},
+        })
+
+    cb = {
+        "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+        "block_id": block_id,
+        "created_at": _utc_now_iso_ms(),
+        "source": {"user_id": None, "ip": _req_ip(), "ua": _req_ua(), "trigger_page": "history", "trigger_source": "history_rollback"},
+        "operation_source": "history_rollback",
+        "reason": "Rollback",
+        "status": "created",
+        "undo_status": "not_run",
+        "repeat_status": "not_run",
+        "affected_count": len(change_items),
+        "series_summary": {},
+    }
+    try:
+        save_change_block(cb, items=change_items)
+        out = undo_change_block(block_id)
+        if not out.get("ok"):
+            return jsonify({"ok": False, "error": "conflict", "validation": out.get("validation"), "change_block_id": block_id}), 409
+        applied = int(out.get("applied") or 0)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e) or e.__class__.__name__}), 500
+
+    # Record rollback events in history (audit)
+    for it in wanted:
+        action = str(it.get("action") or "").strip().lower()
+        if action not in ("overwrite", "delete"):
+            continue
+        s = it.get("series") if isinstance(it.get("series"), dict) else {}
+        measurement = str(s.get("measurement") or "").strip()
+        field = str(s.get("field") or "").strip()
+        tags = s.get("tags") if isinstance(s.get("tags"), dict) else {}
+        t_raw = str(it.get("time") or "").strip()
+        _history_append({
+            "kind": "rollback",
+            "ref_id": it.get("id"),
+            "series": {
+                "measurement": measurement,
+                "field": field,
+                "entity_id": s.get("entity_id"),
+                "friendly_name": s.get("friendly_name"),
+                "tags": tags,
+            },
+            "time": t_raw,
+            "action": "rollback",
+            "old_value": it.get("new_value"),
+            "new_value": it.get("old_value"),
+            "reason": "Rollback",
+            "change_block_id": block_id,
+            "ip": _req_ip(),
+            "ua": _req_ua(),
+        })
+
         try:
-            with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False):
-                pass
+            dirty_series.add((measurement, field, str(s.get("entity_id") or "").strip() or None, str(s.get("friendly_name") or "").strip() or None))
         except Exception:
-            raise RuntimeError("backup not found")
-
-        wapi = c.write_api(write_options=SYNCHRONOUS)
-        batch: list[str] = []
-        applied_local = 0
-        with _open_backup_lp_text(bdir, backup_id, is_fullbackup=False) as f:
-            for line in f:
-                line = line.strip("\n")
-                if not line.strip():
-                    continue
-                batch.append(line)
-                if len(batch) >= 2000:
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                    applied_local += len(batch)
-                    batch = []
-            if batch:
-                wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                applied_local += len(batch)
-        return applied_local
-
-    applied = 0
-    with v2_client(cfg) as c:
-        wapi = c.write_api(write_options=SYNCHRONOUS)
-
-        for it in wanted:
-            action = str(it.get("action") or "").strip().lower()
-
-            if action == "combine_copy":
-                # Roll back by deleting the affected target range and restoring a range-backup.
-                try:
-                    s = it.get("series") or {}
-                    measurement = str(s.get("measurement") or "").strip()
-                    field = str(s.get("field") or "").strip()
-                    entity_id = str(s.get("entity_id") or "").strip() or None
-                    friendly_name = str(s.get("friendly_name") or "").strip() or None
-                    if not measurement or not field:
-                        continue
-                    if not entity_id and not friendly_name:
-                        continue
-
-                    start_s = str(it.get("start") or "").strip()
-                    stop_s = str(it.get("stop") or "").strip()
-                    start_dt = _parse_iso_datetime(start_s)
-                    stop_dt = _parse_iso_datetime(stop_s)
-                    if not start_dt or not stop_dt:
-                        continue
-
-                    backup_id = str(it.get("backup_id") or "").strip()
-                    if not backup_id:
-                        continue
-
-                    predicate = f"_measurement={_flux_str(measurement)} AND _field={_flux_str(field)}"
-                    if entity_id:
-                        predicate += f" AND entity_id={_flux_str(entity_id)}"
-                    if friendly_name:
-                        predicate += f" AND friendly_name={_flux_str(friendly_name)}"
-                    c.delete_api().delete(start=start_dt, stop=stop_dt, predicate=predicate, bucket=cfg["bucket"], org=cfg["org"])
-
-                    restored = _restore_backup_into_client(c, backup_id)
-
-                    _history_append({
-                        "kind": "rollback",
-                        "ref_id": it.get("id"),
-                        "series": {
-                            "measurement": measurement,
-                            "field": field,
-                            "entity_id": entity_id,
-                            "friendly_name": friendly_name,
-                            "tags": {"entity_id": entity_id, "friendly_name": friendly_name},
-                        },
-                        "start": start_s,
-                        "stop": stop_s,
-                        "action": "rollback",
-                        "reason": "Rollback combine_copy",
-                        "backup_id": backup_id,
-                        "restored": restored,
-                        "ip": _req_ip(),
-                        "ua": _req_ua(),
-                    })
-
-                    applied += restored
-                    try:
-                        dirty_series.add((measurement, field, entity_id, friendly_name))
-                    except Exception:
-                        pass
-                except Exception:
-                    continue
-                continue
-
-            if action not in ("overwrite", "delete"):
-                # Ignore other entries (e.g., rollbacks)
-                continue
-            s = it.get("series") or {}
-            measurement = str(s.get("measurement") or "").strip()
-            field = str(s.get("field") or "").strip()
-            tags = s.get("tags") or {}
-            if not isinstance(tags, dict):
-                tags = {}
-            t_raw = str(it.get("time") or "").strip()
-            try:
-                dt = _parse_iso_datetime(t_raw)
-            except Exception:
-                continue
-            old_val = it.get("old_value")
-            if old_val is None:
-                continue
-
-            p = Point(measurement)
-            for tk, tv in tags.items():
-                if tk and tv is not None:
-                    p = p.tag(str(tk), str(tv))
-            p = p.field(field, old_val).time(dt, WritePrecision.NS)
-            wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=p)
-
-            _history_append({
-                "kind": "rollback",
-                "ref_id": it.get("id"),
-                "series": {
-                    "measurement": measurement,
-                    "field": field,
-                    "entity_id": s.get("entity_id"),
-                    "friendly_name": s.get("friendly_name"),
-                    "tags": tags,
-                },
-                "time": t_raw,
-                "action": "rollback",
-                "old_value": it.get("new_value"),
-                "new_value": old_val,
-                "reason": "Rollback",
-                "ip": _req_ip(),
-                "ua": _req_ua(),
-            })
-
-            applied += 1
-
-            try:
-                dirty_series.add((measurement, field, str(s.get("entity_id") or "").strip() or None, str(s.get("friendly_name") or "").strip() or None))
-            except Exception:
-                pass
+            pass
 
     try:
         for m, f, eid, fn in dirty_series:
@@ -31391,7 +32484,7 @@ def api_history_rollback():
     except Exception:
         pass
 
-    return jsonify({"ok": True, "applied": applied, "message": f"Rollback applied: {applied}"})
+    return jsonify({"ok": True, "applied": applied, "message": f"Rollback applied: {applied}", "change_block_id": block_id})
 
 
 def _safe_data_file(root: Path, name: str) -> Path:
@@ -32193,27 +33286,190 @@ from(bucket: "{cfg["bucket"]}")
             return jsonify({"ok": False, "error": f"backup_before failed: {_short_influx_error(e)}"}), 500
 
     try:
-        with v2_client(cfg) as c:
-            if delete_first:
-                predicate = f"_measurement={_flux_str(measurement)} AND _field={_flux_str(field)}"
-                if entity_id:
-                    predicate += f" AND entity_id={_flux_str(entity_id)}"
-                if friendly_name:
-                    predicate += f" AND friendly_name={_flux_str(friendly_name)}"
-                c.delete_api().delete(start=oldest_utc, stop=newest_utc, predicate=predicate, bucket=cfg["bucket"], org=cfg["org"])
+        parent_id = uuid.uuid4().hex
+        undo_supported = bool(delete_first)
+        parent = {
+            "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+            "block_id": parent_id,
+            "created_at": _utc_now_iso_ms(),
+            "source": {
+                "user_id": None,
+                "ip": _req_ip(),
+                "ua": _req_ua(),
+                "trigger_page": "import",
+                "trigger_source": "import_start",
+                "trigger_action": "import",
+                "trigger_button": None,
+            },
+            "operation_source": "import_start",
+            "reason": "import",
+            "status": "created",
+            "undo_status": "not_run",
+            "repeat_status": "not_run",
+            "affected_count": 0,
+            "payload_mode": "inline",
+            "payload_inline": [],
+            "series_summary": {
+                "measurement": measurement,
+                "field": field,
+                "entity_id": entity_id,
+                "friendly_name": friendly_name,
+            },
+            "meta": {
+                "child_blocks": [],
+                "undo_supported": undo_supported,
+                "delete_first": bool(delete_first),
+                "backup_before": bool(backup_before),
+                "backup_id": (backup_meta or {}).get("id") if backup_meta else None,
+            },
+        }
+        save_change_block(parent, items=[])
 
-            wapi = c.write_api(write_options=SYNCHRONOUS)
-            batch: list[Point] = []
-            imported = 0
-            for p in points:
-                batch.append(p)
-                if len(batch) >= 500:
-                    wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                    imported += len(batch)
-                    batch = []
-            if batch:
-                wapi.write(bucket=cfg["bucket"], org=cfg["org"], record=batch, write_precision=WritePrecision.NS)
-                imported += len(batch)
+        child_ids: list[str] = []
+        chunk_idx = 0
+        imported = 0
+        deleted = 0
+
+        def exec_child(items: list[dict[str, Any]], *, kind: str) -> None:
+            nonlocal chunk_idx, imported, deleted
+            if not items:
+                return
+            cid = uuid.uuid4().hex
+            cb = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": cid,
+                "created_at": _utc_now_iso_ms(),
+                "source": parent["source"],
+                "operation_source": "import_start",
+                "reason": f"import:{kind}#{chunk_idx}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": len(items),
+                "series_summary": parent.get("series_summary") or {},
+                "meta": {
+                    "parent_block_id": parent_id,
+                    "chunk_index": chunk_idx,
+                    "kind": kind,
+                    "undo_supported": undo_supported,
+                },
+            }
+            save_change_block(cb, items=items)
+            out = execute_change_block(cid)
+            if not out.get("ok"):
+                raise RuntimeError("import conflict")
+            try:
+                n = int(out.get("applied") or 0)
+            except Exception:
+                n = 0
+            if kind == "delete":
+                deleted += n
+            else:
+                imported += n
+            child_ids.append(cid)
+            chunk_idx += 1
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+        max_items = 5000
+
+        # Optional delete-first implemented as exact point deletes.
+        if delete_first:
+            extra = flux_tag_filter(entity_id, friendly_name)
+            q_del = f'''
+from(bucket: "{cfg["bucket"]}")
+  |> range(start: time(v: "{_dt_to_rfc3339_utc_full(oldest_utc)}"), stop: time(v: "{_dt_to_rfc3339_utc_full(newest_utc)}"))
+  |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
+  |> group()
+  |> sort(columns: ["_time"])
+'''
+            del_items: list[dict[str, Any]] = []
+            with v2_client(cfg) as c:
+                qapi = c.query_api()
+                for rec in qapi.query_stream(q_del, org=cfg["org"]):
+                    t = rec.get_time()
+                    v = rec.get_value()
+                    if not isinstance(t, datetime):
+                        continue
+                    if isinstance(v, bool) or not isinstance(v, (int, float)):
+                        continue
+                    tags: dict[str, str] = {}
+                    for k, tv in (rec.values or {}).items():
+                        if k in ("result", "table"):
+                            continue
+                        if str(k).startswith("_"):
+                            continue
+                        if tv is None:
+                            continue
+                        tags[str(k)] = str(tv)
+                    ts = _dt_to_rfc3339_utc_full(t.astimezone(timezone.utc))
+                    pid = {
+                        "bucket": str(cfg.get("bucket") or ""),
+                        "org": str(cfg.get("org") or ""),
+                        "measurement": measurement,
+                        "field": field,
+                        "timestamp": ts,
+                        "tag_set": tags,
+                    }
+                    old_row = {"_time": ts, "_measurement": measurement, "_field": field, "_value": v, **tags}
+                    del_items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "delete",
+                        "point_identity": pid,
+                        "old_point": old_row,
+                        "new_point": None,
+                        "conflict_policy": "blind",
+                    })
+                    if len(del_items) >= max_items:
+                        exec_child(del_items, kind="delete")
+                        del_items = []
+            exec_child(del_items, kind="delete")
+
+        # Write/import points.
+        wr_items: list[dict[str, Any]] = []
+        op = "create" if delete_first else "update"
+        for p in points:
+            try:
+                lp = p.to_line_protocol()
+            except Exception:
+                lp = None
+            if not lp:
+                continue
+            pts = _lp_parse_points_from_line(lp)
+            if not pts:
+                continue
+            for row in pts:
+                ts = str(row.get("_time") or "").strip()
+                meas = str(row.get("_measurement") or "").strip()
+                fld = str(row.get("_field") or "").strip()
+                if not ts or not meas or not fld:
+                    continue
+                tags = {k: str(v) for k, v in row.items() if k and not str(k).startswith("_") and v is not None}
+                pid = {
+                    "bucket": str(cfg.get("bucket") or ""),
+                    "org": str(cfg.get("org") or ""),
+                    "measurement": meas,
+                    "field": fld,
+                    "timestamp": ts,
+                    "tag_set": tags,
+                }
+                wr_items.append({
+                    "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                    "item_id": uuid.uuid4().hex,
+                    "block_id": "",
+                    "op": op,
+                    "point_identity": pid,
+                    "old_point": None,
+                    "new_point": row,
+                    "conflict_policy": "blind",
+                })
+                if len(wr_items) >= max_items:
+                    exec_child(wr_items, kind="write")
+                    wr_items = []
+        exec_child(wr_items, kind="write")
+
+        _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "imported": imported, "deleted": deleted})
 
         _history_append({
             "kind": "import",
@@ -32227,6 +33483,7 @@ from(bucket: "{cfg["bucket"]}")
             "delete_first": delete_first,
             "backup_before": backup_before,
             "backup_id": (backup_meta or {}).get("id") if backup_meta else None,
+            "change_block_id": parent_id,
             "reason": "Import",
             "ip": _req_ip(),
             "ua": _req_ua(),
@@ -32240,6 +33497,19 @@ from(bucket: "{cfg["bucket"]}")
         except Exception:
             pass
 
+        try:
+            _undo_mgr(cfg).register_action(
+                action_type="update",
+                bucket=str(cfg.get("bucket") or ""),
+                measurement=measurement,
+                group_label=f"import ({imported})",
+                before_rows=[],
+                after_rows=[],
+                meta={"change_block_id": parent_id, "undo_supported": undo_supported},
+            )
+        except Exception:
+            pass
+
         return jsonify({
             "ok": True,
             "imported": imported,
@@ -32247,6 +33517,7 @@ from(bucket: "{cfg["bucket"]}")
             "backup": backup_meta,
             "checks": plan["checks"],
             "message": f"Import fertig. Zeilen: {imported}",
+            "change_block_id": parent_id,
         })
     except Exception as e:
         return jsonify({"ok": False, "error": _short_influx_error(e)}), 500
@@ -32283,22 +33554,162 @@ def delete():
                     "ok": False,
                     "error": "InfluxDB v2 requires token, org, bucket. Bitte in /config YAML einlesen und speichern.",
                 }), 400
-            predicate = f"_measurement={_flux_str(measurement)}"
-            if field:
-                predicate += f" AND _field={_flux_str(field)}"
-            if entity_id:
-                predicate += f" AND entity_id={_flux_str(entity_id)}"
-            if friendly_name:
-                predicate += f" AND friendly_name={_flux_str(friendly_name)}"
+            # Change-Service delete: expand to exact point deletes.
+            parent_id = uuid.uuid4().hex
+            extra = flux_tag_filter(entity_id, friendly_name)
+            q = f'''
+from(bucket: "{cfg["bucket"]}")
+  |> range(start: time(v: "{_dt_to_rfc3339_utc_full(start)}"), stop: time(v: "{_dt_to_rfc3339_utc_full(stop)}"))
+  |> filter(fn: (r) => r._measurement == {_flux_str(measurement)}{(' and r._field == ' + _flux_str(field)) if field else ''}{extra})
+  |> group()
+  |> sort(columns: ["_time"])
+'''
+
+            parent = {
+                "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                "block_id": parent_id,
+                "created_at": _utc_now_iso_ms(),
+                "source": {
+                    "user_id": None,
+                    "ip": _req_ip(),
+                    "ua": _req_ua(),
+                    "trigger_page": "raw",
+                    "trigger_source": "delete",
+                    "trigger_action": "delete",
+                    "trigger_button": None,
+                },
+                "operation_source": "delete",
+                "reason": f"delete:{range_key}",
+                "status": "created",
+                "undo_status": "not_run",
+                "repeat_status": "not_run",
+                "affected_count": 0,
+                "payload_mode": "inline",
+                "payload_inline": [],
+                "series_summary": {
+                    "measurement": measurement,
+                    "field": field,
+                    "entity_id": entity_id,
+                    "friendly_name": friendly_name,
+                },
+                "meta": {
+                    "child_blocks": [],
+                    "undo_supported": True,
+                    "range": {"start": _dt_to_rfc3339_utc_full(start), "stop": _dt_to_rfc3339_utc_full(stop)},
+                    "range_key": range_key,
+                },
+            }
+            save_change_block(parent, items=[])
+
+            child_ids: list[str] = []
+            chunk_idx = 0
+            deleted = 0
+
+            def exec_child(items: list[dict[str, Any]]) -> None:
+                nonlocal chunk_idx, deleted
+                if not items:
+                    return
+                cid = uuid.uuid4().hex
+                cb = {
+                    "schema_version": CHANGE_BLOCK_SCHEMA_VERSION,
+                    "block_id": cid,
+                    "created_at": _utc_now_iso_ms(),
+                    "source": parent["source"],
+                    "operation_source": "delete",
+                    "reason": f"delete:{range_key}#{chunk_idx}",
+                    "status": "created",
+                    "undo_status": "not_run",
+                    "repeat_status": "not_run",
+                    "affected_count": len(items),
+                    "series_summary": parent.get("series_summary") or {},
+                    "meta": {"parent_block_id": parent_id, "chunk_index": chunk_idx, "undo_supported": True},
+                }
+                save_change_block(cb, items=items)
+                out = execute_change_block(cid)
+                if not out.get("ok"):
+                    raise RuntimeError("delete conflict")
+                try:
+                    deleted += int(out.get("applied") or 0)
+                except Exception:
+                    pass
+                child_ids.append(cid)
+                chunk_idx += 1
+                _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids)})
+
+            max_items = 5000
+            items: list[dict[str, Any]] = []
             with v2_client(cfg) as c:
-                c.delete_api().delete(start=start, stop=stop, predicate=predicate, bucket=cfg["bucket"], org=cfg["org"])
+                qapi = c.query_api()
+                for rec in qapi.query_stream(q, org=cfg["org"]):
+                    t = rec.get_time()
+                    v = rec.get_value()
+                    if not isinstance(t, datetime):
+                        continue
+                    if isinstance(v, bool) or not isinstance(v, (int, float)):
+                        continue
+                    meas = str(rec.values.get("_measurement") or measurement)
+                    fld = str(rec.values.get("_field") or field)
+                    if not meas or not fld:
+                        continue
+                    tags: dict[str, str] = {}
+                    for k, tv in (rec.values or {}).items():
+                        if k in ("result", "table"):
+                            continue
+                        if str(k).startswith("_"):
+                            continue
+                        if tv is None:
+                            continue
+                        tags[str(k)] = str(tv)
+                    ts = _dt_to_rfc3339_utc_full(t.astimezone(timezone.utc))
+                    pid = {
+                        "bucket": str(cfg.get("bucket") or ""),
+                        "org": str(cfg.get("org") or ""),
+                        "measurement": meas,
+                        "field": fld,
+                        "timestamp": ts,
+                        "tag_set": tags,
+                    }
+                    old_row = {"_time": ts, "_measurement": meas, "_field": fld, "_value": v, **tags}
+                    items.append({
+                        "schema_version": CHANGE_ITEM_SCHEMA_VERSION,
+                        "item_id": uuid.uuid4().hex,
+                        "block_id": "",
+                        "op": "delete",
+                        "point_identity": pid,
+                        "old_point": old_row,
+                        "new_point": None,
+                        "conflict_policy": "blind",
+                    })
+                    if len(items) >= max_items:
+                        exec_child(items)
+                        items = []
+            exec_child(items)
+
+            _cb_patch_block_meta(parent_id, {"child_blocks": list(child_ids), "deleted": deleted})
+            try:
+                _undo_mgr(cfg).register_action(
+                    action_type="delete",
+                    bucket=str(cfg.get("bucket") or ""),
+                    measurement=measurement,
+                    group_label=f"delete ({deleted})",
+                    before_rows=[],
+                    after_rows=[],
+                    meta={"change_block_id": parent_id, "undo_supported": True},
+                )
+            except Exception:
+                pass
             try:
                 _dash_cache_mark_dirty_series(measurement, field, str(entity_id) if entity_id else None, str(friendly_name) if friendly_name else None, "delete")
                 _stats_cache_mark_dirty_series(measurement, field, str(entity_id) if entity_id else None, str(friendly_name) if friendly_name else None, "delete")
                 _analysis_cache_mark_dirty_series(cfg, measurement, field, str(entity_id) if entity_id else None, str(friendly_name) if friendly_name else None, "delete")
             except Exception:
                 pass
-            return jsonify({"ok": True, "message": f"Deleted v2: {predicate} in {cfg['bucket']} from {start.isoformat()} to {stop.isoformat()}"})
+            return jsonify({
+                "ok": True,
+                "deleted": deleted,
+                "change_block_id": parent_id,
+                "message": f"Deleted v2 points: {deleted} in {cfg['bucket']} from {start.isoformat()} to {stop.isoformat()}",
+            })
         else:
             if not cfg.get("database"):
                 return jsonify({"ok": False, "error": "InfluxDB v1 requires database. Bitte konfigurieren."}), 400

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -1286,6 +1286,12 @@ DEFAULT_CFG = {
     "ui_table_header_bg": "#0B1F3A",
     "ui_table_header_fg": "#FFFFFF",
 
+    # Theme / design tokens (MVP)
+    # Values: system|light|dark|dark_blue|high_contrast
+    "ui_theme_mode": "system",
+    # Values: blue|green|orange|violet|red|cyan
+    "ui_theme_accent": "blue",
+
     # Global (device-independent) settings page layout overrides.
     # Stored as a small JSON-like object; used by the Settings Organizer UI.
     "settings_layout": {},
@@ -19455,6 +19461,22 @@ def api_set_config():
     if m not in ("new_tab", "same_tab", "modal"):
         m = "new_tab"
     cfg["ui_tooltip_doc_open_mode"] = m
+
+    # Theme mode / accent (global)
+    try:
+        tm = str(cfg.get("ui_theme_mode") or "system").strip().lower()
+    except Exception:
+        tm = "system"
+    if tm not in ("system", "light", "dark", "dark_blue", "high_contrast"):
+        tm = "system"
+    cfg["ui_theme_mode"] = tm
+    try:
+        ta = str(cfg.get("ui_theme_accent") or "blue").strip().lower()
+    except Exception:
+        ta = "blue"
+    if ta not in ("blue", "green", "orange", "violet", "red", "cyan"):
+        ta = "blue"
+    cfg["ui_theme_accent"] = ta
 
     # Settings layout overrides (global UI structure for /config).
     # Keep the structure small and strictly typed (no HTML).

--- a/influxbro/app/templates/_topbar.html
+++ b/influxbro/app/templates/_topbar.html
@@ -410,9 +410,200 @@
       line-height: 1;
     }
     main.content details[open] > summary::before { transform: rotate(90deg); }
+
+    /* Theme system (MVP) (#405)
+       Applies via html[data-theme] + html[data-accent]. */
+    :root {
+      --ib-bg: #f7f8fa;
+      --ib-surface: #ffffff;
+      --ib-surface-2: #f1f3f6;
+      --ib-text: #1f2933;
+      --ib-text-muted: #6b7280;
+      --ib-border: #d7dce2;
+
+      --ib-primary: #2563eb;
+      --ib-primary-text: #ffffff;
+
+      --ib-success: #14803c;
+      --ib-warning: #b7791f;
+      --ib-danger: #c53030;
+      --ib-info: #2563eb;
+
+      /* Integrate existing per-UI header color knobs */
+      --ib-table-header-bg: var(--ib-table-head-bg);
+      --ib-table-header-text: var(--ib-table-head-fg);
+      --ib-table-row-hover: #e8f1ff;
+      --ib-table-selected: #dbeafe;
+
+      --ib-input-bg: #ffffff;
+      --ib-input-text: #111827;
+
+      --ib-button-bg: #eef3ff;
+      --ib-button-text: #103a7c;
+      --ib-button-border: #cad7f2;
+      --ib-button-hover-bg: #dce7ff;
+      --ib-button-active-bg: #cddcff;
+
+      /* Map existing button variables */
+      --ib-btn-bg: var(--ib-button-bg);
+      --ib-btn-fg: var(--ib-button-text);
+      --ib-btn-border: var(--ib-button-border);
+      --ib-btn-hover-bg: var(--ib-button-hover-bg);
+      --ib-btn-active-bg: var(--ib-button-active-bg);
+    }
+
+    html[data-theme="dark"] {
+      --ib-bg: #0f1115;
+      --ib-surface: #161a22;
+      --ib-surface-2: #1d2330;
+      --ib-text: #e5e7eb;
+      --ib-text-muted: #9aa4b2;
+      --ib-border: #2a3345;
+
+      --ib-table-row-hover: rgba(99, 102, 241, 0.14);
+      --ib-table-selected: rgba(59, 130, 246, 0.22);
+
+      --ib-input-bg: #121726;
+      --ib-input-text: #e5e7eb;
+
+      --ib-button-bg: #1c2436;
+      --ib-button-text: #e5e7eb;
+      --ib-button-border: #2a3345;
+      --ib-button-hover-bg: #25304a;
+      --ib-button-active-bg: #2c3a5b;
+    }
+
+    html[data-theme="dark_blue"] {
+      --ib-bg: #061325;
+      --ib-surface: #0b1b33;
+      --ib-surface-2: #102542;
+      --ib-text: #dbe7ff;
+      --ib-text-muted: #9bb0d6;
+      --ib-border: #1a355a;
+
+      --ib-table-row-hover: rgba(34, 211, 238, 0.10);
+      --ib-table-selected: rgba(59, 130, 246, 0.20);
+
+      --ib-input-bg: #081a33;
+      --ib-input-text: #dbe7ff;
+
+      --ib-button-bg: #0f2547;
+      --ib-button-text: #dbe7ff;
+      --ib-button-border: #1a355a;
+      --ib-button-hover-bg: #14305c;
+      --ib-button-active-bg: #183a6f;
+    }
+
+    html[data-theme="high_contrast"] {
+      --ib-bg: #000000;
+      --ib-surface: #000000;
+      --ib-surface-2: #0b0b0c;
+      --ib-text: #ffffff;
+      --ib-text-muted: #d1d5db;
+      --ib-border: #ffffff;
+
+      --ib-input-bg: #000000;
+      --ib-input-text: #ffffff;
+
+      --ib-button-bg: #ffffff;
+      --ib-button-text: #000000;
+      --ib-button-border: #ffffff;
+      --ib-button-hover-bg: #e5e7eb;
+      --ib-button-active-bg: #d1d5db;
+    }
+
+    html[data-accent="blue"] { --ib-primary: #2563eb; }
+    html[data-accent="green"] { --ib-primary: #16a34a; }
+    html[data-accent="orange"] { --ib-primary: #f97316; }
+    html[data-accent="violet"] { --ib-primary: #7c3aed; }
+    html[data-accent="red"] { --ib-primary: #ef4444; }
+    html[data-accent="cyan"] { --ib-primary: #06b6d4; }
+
+    body { background: var(--ib-bg) !important; color: var(--ib-text) !important; }
+    .muted { color: var(--ib-text-muted) !important; }
+
+    .card,
+    .table_wrap,
+    .table_box,
+    .space_box,
+    .status,
+    .ib_section_desc_row {
+      background: var(--ib-surface) !important;
+      border-color: var(--ib-border) !important;
+      color: var(--ib-text) !important;
+    }
+
+    input, select, textarea {
+      background: var(--ib-input-bg) !important;
+      color: var(--ib-input-text) !important;
+      border-color: var(--ib-border) !important;
+    }
+
+    th { background: var(--ib-table-header-bg) !important; color: var(--ib-table-header-text) !important; }
+    th, td { border-color: var(--ib-border) !important; }
+    tr.selected { background: var(--ib-table-selected) !important; }
+    tbody tr:hover td { background: var(--ib-table-row-hover) !important; }
+
+    .err { color: var(--ib-danger) !important; }
+    .ok { color: var(--ib-success) !important; }
+
+    .ib_topbar { background: color-mix(in srgb, var(--ib-surface) 96%, transparent) !important; border-bottom: 1px solid var(--ib-border) !important; }
+    .ib_topbar .zoom { border-left: 1px solid var(--ib-border) !important; }
+    .ib_cfg_icon, .ib_cfg_back_icon { background: var(--ib-surface) !important; color: var(--ib-text) !important; border-color: var(--ib-border) !important; }
   </style>
 
   <div style="display:none"></div>
+
+  <script>
+  (function(){
+    const CFG_MODE = String({{ ((cfg.get('ui_theme_mode') or 'system') if cfg else 'system') | tojson }} || 'system');
+    const CFG_ACC = String({{ ((cfg.get('ui_theme_accent') or 'blue') if cfg else 'blue') | tojson }} || 'blue');
+
+    let _mql = null;
+    let _onSystemChange = null;
+    function _applyTheme(theme){
+      try{ document.documentElement.setAttribute('data-theme', String(theme || 'light')); }catch(e){}
+    }
+    function _applyAccent(acc){
+      try{ document.documentElement.setAttribute('data-accent', String(acc || 'blue')); }catch(e){}
+    }
+    function apply(mode, accent){
+      const m = String(mode || 'system').trim().toLowerCase();
+      const a = String(accent || 'blue').trim().toLowerCase();
+      _applyAccent(a);
+
+      try{ if(_mql && _onSystemChange && _mql.removeEventListener) _mql.removeEventListener('change', _onSystemChange); }catch(e){}
+      try{ if(_mql && _onSystemChange && _mql.removeListener) _mql.removeListener(_onSystemChange); }catch(e){}
+      _mql = null;
+      _onSystemChange = null;
+
+      if(m === 'system'){
+        try{
+          _mql = window.matchMedia('(prefers-color-scheme: dark)');
+          const isDark = !!(_mql && _mql.matches);
+          _applyTheme(isDark ? 'dark' : 'light');
+          _onSystemChange = ()=>{ try{ _applyTheme(_mql && _mql.matches ? 'dark' : 'light'); }catch(e){} };
+          try{ if(_mql && _mql.addEventListener) _mql.addEventListener('change', _onSystemChange); }catch(e){}
+          try{ if(_mql && _mql.addListener) _mql.addListener(_onSystemChange); }catch(e){}
+        }catch(e){
+          _applyTheme('light');
+        }
+        return;
+      }
+      _applyTheme(m);
+    }
+
+    window.InfluxBroTheme = {
+      apply: apply,
+      get: ()=>({
+        mode: String(document.documentElement.getAttribute('data-theme') || ''),
+        accent: String(document.documentElement.getAttribute('data-accent') || ''),
+      }),
+    };
+
+    apply(CFG_MODE, CFG_ACC);
+  })();
+  </script>
 
   <script>
   (function(){

--- a/influxbro/app/templates/combine.html
+++ b/influxbro/app/templates/combine.html
@@ -875,7 +875,8 @@
           stop: stopIso,
         })});
         JOB_ID = String(j.job_id || '');
-        setInfo(['Job gestartet: ' + JOB_ID, '']);
+        const bid = String(j.change_block_id || '').trim();
+        setInfo(['Job gestartet: ' + JOB_ID, bid ? ('ChangeBlock: ' + bid) : '']);
         beginPoll();
       }
 
@@ -895,9 +896,11 @@
             const el = String(st.elapsed || '');
             const applied = (st.written !== null && st.written !== undefined) ? String(st.written) : '';
             const skipped = (st.skipped !== null && st.skipped !== undefined) ? String(st.skipped) : '';
+            const bid = String(st.change_block_id || '').trim();
             setInfo([
               `Status: ${state} | Laufzeit: ${el}`,
               msg ? ('Aktion: ' + msg) : '',
+              bid ? ('ChangeBlock: ' + bid) : '',
               applied ? ('geschrieben: ' + applied) : '',
               skipped ? ('skipped: ' + skipped) : '',
             ]);

--- a/influxbro/app/templates/config.html
+++ b/influxbro/app/templates/config.html
@@ -743,8 +743,33 @@
 
         <details class="card" id="ui_layout" open data-ui="config_settings.section_root" title="settings.ui.layout">
           <summary><span class="ib_summary_row"><span>Darstellung</span><button type="button" class="ib_info_icon" data-info-title="Einstellungen: Darstellung" data-info-body="Optische/UX Einstellungen (z.B. Zoom, Tooltips, Auto-Breite der Auswahlfelder).\n\nHinweis:\n- Einige Werte werden im Browser gespeichert (UI-State), andere in /data (Addon-Config)." ><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M12 17V11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="12" cy="8" r="1" fill="currentColor"/><path d="M7 3.33782C8.47087 2.48697 10.1786 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 10.1786 2.48697 8.47087 3.33782 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg></button></span></summary>
-          <div class="card_body">
-            <div class="grid">
+           <div class="card_body">
+             <div class="grid">
+              <div class="param_row" data-ui="config_ui_theme.row_mode" data-ib-pickkey="config_ui_theme.row_mode" title="settings.ui.theme.mode">
+                <div class="param_label">Farbschema<span class="param_hint">MVP: System, Hell, Dunkel, Dunkel Blau, Hoher Kontrast. Wirkt sofort (ohne Neustart).</span></div>
+                <div class="param_control">
+                  <select id="ui_theme_mode" data-ui="config_ui_theme.select_mode" data-ib-pickkey="config_ui_theme.select_mode" title="settings.ui.theme.mode" style="width:100%; max-width: 320px;">
+                    <option value="system">System</option>
+                    <option value="light">Hell</option>
+                    <option value="dark">Dunkel</option>
+                    <option value="dark_blue">Dunkel Blau</option>
+                    <option value="high_contrast">Hoher Kontrast</option>
+                  </select>
+                </div>
+              </div>
+              <div class="param_row" data-ui="config_ui_theme.row_accent" data-ib-pickkey="config_ui_theme.row_accent" title="settings.ui.theme.accent">
+                <div class="param_label">Akzentfarbe<span class="param_hint">Beeinflusst Primary/Highlights (Buttons, Markierungen).</span></div>
+                <div class="param_control">
+                  <select id="ui_theme_accent" data-ui="config_ui_theme.select_accent" data-ib-pickkey="config_ui_theme.select_accent" title="settings.ui.theme.accent" style="width:100%; max-width: 320px;">
+                    <option value="blue">Blau</option>
+                    <option value="green">Gruen</option>
+                    <option value="orange">Orange</option>
+                    <option value="violet">Violett</option>
+                    <option value="red">Rot</option>
+                    <option value="cyan">Cyan</option>
+                  </select>
+                </div>
+              </div>
               <div class="param_row">
                 <div class="param_label">GUI Gruppe 1: Titelzeile / Haupttitel (px)<span class="param_hint">Seitentitel in der festen Titelkarte, Brand-Titel (InfluxBro), grosse Kopfzeilen. Default: 16.</span></div>
                 <div class="param_control">
@@ -1582,7 +1607,7 @@ const ids = [
   "ui_query_max_points","ui_raw_max_points","ui_raw_center_max_points","ui_raw_center_range_default","ui_raw_center_min_points","ui_raw_target_chunk_ms","ui_analysis_max_age_years",
   "ui_query_manual_max_points","ui_graph_jump_padding_intervals",
   "ui_gui_title_px","ui_gui_heading_px","ui_gui_body_px","ui_gui_meta_px","ui_tbl_title_px","ui_tbl_head_px","ui_tbl_cell_px",
-  "ui_page_search_highlight_color","ui_page_search_highlight_width_px","ui_page_search_highlight_duration_ms","ui_nav_helper_history_limit","ui_nav_helper_highlight_color","ui_nav_helper_highlight_duration_ms","ui_analysis_cache_hidden_color","ui_checkbox_scale",
+  "ui_page_search_highlight_color","ui_page_search_highlight_width_px","ui_page_search_highlight_duration_ms","ui_nav_helper_history_limit","ui_nav_helper_highlight_color","ui_nav_helper_highlight_duration_ms","ui_analysis_cache_hidden_color","ui_checkbox_scale","ui_theme_mode","ui_theme_accent",
   "ui_analysis_cache_missing_color",
   "ui_picker_outline_auto","ui_picker_outline_light_bg","ui_picker_outline_dark_bg","perf_corr_causal_gap_ms","perf_corr_timer_gap_ms","perf_corr_dep_zoom_pct",
   "outlier_gap_seconds_default",
@@ -2648,6 +2673,10 @@ function setForm(cfg){
   _setVal(el.ui_analysis_max_age_years, cfg.ui_analysis_max_age_years ?? 5);
   _setVal(el.ui_decimals, cfg.ui_decimals ?? 3);
 
+  _safeSet(el.ui_theme_mode, 'value', String(cfg.ui_theme_mode ?? 'system'));
+  _safeSet(el.ui_theme_accent, 'value', String(cfg.ui_theme_accent ?? 'blue'));
+  try{ if(window.InfluxBroTheme && window.InfluxBroTheme.apply) window.InfluxBroTheme.apply(el.ui_theme_mode.value, el.ui_theme_accent.value); }catch(e){}
+
   _setVal(el.ui_gui_title_px, cfg.ui_gui_title_px ?? 16);
   _setVal(el.ui_gui_heading_px, cfg.ui_gui_heading_px ?? 14);
   _setVal(el.ui_gui_body_px, cfg.ui_gui_body_px ?? 12);
@@ -2816,6 +2845,9 @@ function getForm(){
     ui_query_manual_max_points: parseInt(el.ui_query_manual_max_points.value, 10),
     ui_graph_jump_padding_intervals: parseInt(el.ui_graph_jump_padding_intervals.value, 10),
     ui_decimals: parseInt(el.ui_decimals.value, 10),
+
+    ui_theme_mode: String(el.ui_theme_mode ? el.ui_theme_mode.value : 'system'),
+    ui_theme_accent: String(el.ui_theme_accent ? el.ui_theme_accent.value : 'blue'),
 
     ui_gui_title_px: parseInt(el.ui_gui_title_px.value, 10),
     ui_gui_heading_px: parseInt(el.ui_gui_heading_px.value, 10),
@@ -3361,6 +3393,12 @@ try{
     elm.addEventListener('change', ()=>{ scheduleAutoSave(); });
     elm.addEventListener('input', ()=>{ scheduleAutoSave(); });
   });
+}catch(e){}
+
+// Live-apply theme changes (instant feedback)
+try{
+  if(el.ui_theme_mode) el.ui_theme_mode.addEventListener('change', ()=>{ try{ window.InfluxBroTheme && window.InfluxBroTheme.apply && window.InfluxBroTheme.apply(el.ui_theme_mode.value, el.ui_theme_accent ? el.ui_theme_accent.value : 'blue'); }catch(e){} });
+  if(el.ui_theme_accent) el.ui_theme_accent.addEventListener('change', ()=>{ try{ window.InfluxBroTheme && window.InfluxBroTheme.apply && window.InfluxBroTheme.apply(el.ui_theme_mode ? el.ui_theme_mode.value : 'system', el.ui_theme_accent.value); }catch(e){} });
 }catch(e){}
 
 

--- a/influxbro/app/templates/history.html
+++ b/influxbro/app/templates/history.html
@@ -434,14 +434,66 @@
       return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     }
 
-    async function cbShowDetails(){
+    function _cbVal(v){
+      try{ return (v === null || v === undefined) ? '' : String(v); }catch(e){ return ''; }
+    }
+
+    function _cbPickValueFromPoint(p){
+      try{ if(!p || typeof p !== 'object') return ''; }catch(e){ return ''; }
+      const v = p._value;
+      return _cbVal(v);
+    }
+
+    function _cbShortTagsFromPoint(p){
+      try{ if(!p || typeof p !== 'object') return ''; }catch(e){ return ''; }
+      const out = [];
+      Object.keys(p).forEach(k=>{
+        if(!k) return;
+        if(k[0] === '_') return;
+        if(k === 'result' || k === 'table') return;
+        const v = p[k];
+        if(v === null || v === undefined) return;
+        out.push(String(k) + '=' + String(v));
+      });
+      out.sort();
+      return out.join(',');
+    }
+
+    function _cbPreviewMapFor(bid, dir){
+      const p = CB_PREVIEWS.get(String(bid||'')) || {};
+      const v = (dir === 'undo') ? (p.undo || null) : (p.repeat || null);
+      const map = new Map();
+      try{
+        const rs = (v && v.results) ? v.results : [];
+        (rs || []).forEach(r=>{
+          if(!r || typeof r !== 'object') return;
+          const iid = String(r.item_id || '').trim();
+          if(!iid) return;
+          map.set(iid, r);
+        });
+      }catch(e){}
+      return map;
+    }
+
+    async function cbShowDetails(opts){
       const bid = _cbPickSelectedOne();
       if(!bid) return;
-      const j = await api('./api/change_block?id=' + encodeURIComponent(bid));
+      const o = opts || {};
+      const off = Number(o.offset || 0) || 0;
+      const lim = Number(o.limit || 200) || 200;
+      const j = await api('./api/change_block?id=' + encodeURIComponent(bid) + '&include_items=1&items_offset=' + encodeURIComponent(String(off)) + '&items_limit=' + encodeURIComponent(String(lim)));
       const b = j.block || {};
       const ss = b.series_summary || {};
       const meta = b.meta || {};
       const child = Array.isArray(meta.child_blocks) ? meta.child_blocks.map(x=>String(x||'').trim()).filter(Boolean) : [];
+      const items = Array.isArray(b.items) ? b.items : [];
+      const total = Number(b.items_total || 0) || items.length;
+      const offset = Number(b.items_offset || 0) || off;
+      const limit = Number(b.items_limit || 0) || lim;
+
+      const undoMap = _cbPreviewMapFor(bid, 'undo');
+      const repMap = _cbPreviewMapFor(bid, 'repeat');
+
       let html = '';
       html += '<div style="font-size:12px;line-height:1.35;">';
       html += '<div><b>block_id</b>: <code>' + _cbHtmlEsc(b.block_id) + '</code></div>';
@@ -452,17 +504,80 @@
       html += '<div><b>status</b>: ' + _cbHtmlEsc(String(b.status||'')) + ' | <b>undo</b>: ' + _cbHtmlEsc(String(b.undo_status||'')) + ' | <b>repeat</b>: ' + _cbHtmlEsc(String(b.repeat_status||'')) + '</div>';
       html += '<div style="margin-top:8px;"><b>series</b>: ' + _cbHtmlEsc([ss.measurement, ss.field, ss.entity_id, ss.friendly_name].filter(Boolean).join(' | ')) + '</div>';
       if(child.length){
-        html += '<div style="margin-top:8px;"><b>child_blocks</b> (' + String(child.length) + '):</div>';
-        html += '<div class="mono" style="white-space:pre-wrap;">' + _cbHtmlEsc(child.join('\n')) + '</div>';
+        html += '<div style="margin-top:8px;"><b>child_blocks</b> (' + String(child.length) + ')</div>';
       }
+      html += '<div style="margin-top:8px;"><b>items</b>: ' + String(total) + ' (zeigt ' + String(items.length) + ' ab offset ' + String(offset) + ')</div>';
+
+      html += '<div style="margin-top:10px; border:1px solid rgba(0,0,0,0.12); border-radius:10px; overflow:auto; max-height:52vh;">';
+      html += '<table class="ib_tbl" style="min-width:960px;">';
+      html += '<thead><tr>';
+      html += '<th style="width:120px;">item</th>';
+      html += '<th style="width:70px;">op</th>';
+      html += '<th style="width:170px;">time</th>';
+      html += '<th style="width:160px;">measurement</th>';
+      html += '<th style="width:140px;">field</th>';
+      html += '<th style="width:240px;">tags</th>';
+      html += '<th style="width:110px;">old</th>';
+      html += '<th style="width:110px;">new</th>';
+      html += '<th style="width:140px;">undo preview</th>';
+      html += '<th style="width:140px;">repeat preview</th>';
+      html += '</tr></thead>';
+      html += '<tbody>';
+      items.forEach((it, idx)=>{
+        if(!it || typeof it !== 'object') return;
+        const iid = String(it.item_id || '').trim();
+        const op = String(it.op || '');
+        const pid = (it.point_identity && typeof it.point_identity === 'object') ? it.point_identity : {};
+        const ts = String(pid.timestamp || '');
+        const meas = String(pid.measurement || '');
+        const fld = String(pid.field || '');
+        const tags = (pid.tag_set && typeof pid.tag_set === 'object') ? pid.tag_set : {};
+        const tagsTxt = Object.keys(tags).sort().map(k=>String(k)+'='+String(tags[k])).join(',');
+        const oldv = _cbPickValueFromPoint(it.old_point);
+        const newv = _cbPickValueFromPoint(it.new_point);
+
+        const u = iid ? (undoMap.get(iid) || null) : null;
+        const r = iid ? (repMap.get(iid) || null) : null;
+        function _fmtPrev(p){
+          if(!p) return '-';
+          const st = String(p.state || '');
+          const cur = (p.current_value !== undefined) ? (' cur=' + _cbVal(p.current_value)) : '';
+          const exp = (p.expected_value !== undefined) ? (' exp=' + _cbVal(p.expected_value)) : '';
+          return st + cur + exp;
+        }
+
+        const uTxt = _fmtPrev(u);
+        const rTxt = _fmtPrev(r);
+
+        html += '<tr>';
+        html += '<td>' + _cbHtmlEsc(iid ? iid.slice(0,8) : ('#' + String(offset + idx + 1))) + '</td>';
+        html += '<td>' + _cbHtmlEsc(op) + '</td>';
+        html += '<td>' + _cbHtmlEsc(ts) + '</td>';
+        html += '<td>' + _cbHtmlEsc(meas) + '</td>';
+        html += '<td>' + _cbHtmlEsc(fld) + '</td>';
+        html += '<td style="max-width:240px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="' + _cbHtmlEsc(tagsTxt) + '">' + _cbHtmlEsc(tagsTxt) + '</td>';
+        html += '<td>' + _cbHtmlEsc(oldv) + '</td>';
+        html += '<td>' + _cbHtmlEsc(newv) + '</td>';
+        html += '<td>' + _cbHtmlEsc(uTxt) + '</td>';
+        html += '<td>' + _cbHtmlEsc(rTxt) + '</td>';
+        html += '</tr>';
+      });
+      html += '</tbody></table></div>';
       html += '</div>';
 
       const actions = [
-        { label:'Undo Preview', onClick: ()=>{ cbPreview('undo').catch(e=>err(String(e.message||e))); } },
-        { label:'Repeat Preview', onClick: ()=>{ cbPreview('repeat').catch(e=>err(String(e.message||e))); } },
+        { label:'Undo Preview', onClick: ()=>{ cbPreview('undo').then(()=>cbShowDetails({offset: offset, limit: limit})).catch(e=>err(String(e.message||e))); } },
+        { label:'Repeat Preview', onClick: ()=>{ cbPreview('repeat').then(()=>cbShowDetails({offset: offset, limit: limit})).catch(e=>err(String(e.message||e))); } },
       ];
+      if((offset + items.length) < total){
+        actions.push({ label:'Naechste Items', onClick: ()=>{ cbShowDetails({offset: offset + items.length, limit: limit}).catch(e=>err(String(e.message||e))); } });
+      }
+      if(offset > 0){
+        actions.push({ label:'Vorherige Items', onClick: ()=>{ cbShowDetails({offset: Math.max(0, offset - limit), limit: limit}).catch(e=>err(String(e.message||e))); } });
+      }
+
       if(window.InfluxBroPopup && window.InfluxBroPopup.show){
-        window.InfluxBroPopup.show('ChangeBlock Details', html, { bodyHtml:true, actions });
+        window.InfluxBroPopup.show('ChangeBlock Details', html, { bodyHtml:true, actions, copyText: JSON.stringify(b, null, 2) });
       }else{
         alert('ChangeBlock: ' + bid);
       }

--- a/influxbro/app/templates/history.html
+++ b/influxbro/app/templates/history.html
@@ -160,6 +160,96 @@
         </div>
         </div>
       </details>
+
+      <details class="card" open data-ui="history_cb.section_root" data-ib-pickkey="history_cb.section_root" title="history.change_blocks">
+        <summary><span class="ib_summary_row"><span>ChangeBlocks</span><button type="button" class="ib_info_icon" data-info-title="ChangeBlocks" data-info-body="Zeigt persistente ChangeBlocks (Change-Service) inkl. Preview (validate) und Undo/Repeat." ><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M12 17V11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="12" cy="8" r="1" fill="currentColor"/><path d="M7 3.33782C8.47087 2.48697 10.1786 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 10.1786 2.48697 8.47087 3.33782 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg></button></span></summary>
+        <div class="card_body">
+          <div class="row" data-ui="history_cb.panel_filters" data-ib-pickkey="history_cb.panel_filters" title="history.change_blocks.filters" style="align-items:end;">
+            <div style="min-width: 220px; flex: 1 1 360px;">
+              <label>Suche (id / reason / measurement)</label>
+              <div class="ib_clear_row">
+                <input id="cb_q" placeholder="block_id, reason, operation_source..." data-ui="history_cb.input_search" data-ib-pickkey="history_cb.input_search" title="history.change_blocks.search" style="width:100%;" />
+                <button type="button" class="ib_clear_btn" data-clear-for="cb_q" aria-label="Feld leeren" title="Feld leeren"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M18 6L6 18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M6 6l12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+              </div>
+            </div>
+            <div style="min-width: 180px;">
+              <label>operation_source</label>
+              <input id="cb_op" placeholder="optional" data-ui="history_cb.input_op" data-ib-pickkey="history_cb.input_op" title="history.change_blocks.op" style="width:100%;" />
+            </div>
+            <div style="min-width: 140px;">
+              <label>Status</label>
+              <select id="cb_status" data-ui="history_cb.select_status" data-ib-pickkey="history_cb.select_status" title="history.change_blocks.status" style="width:100%;">
+                <option value="">alle</option>
+                <option value="created">created</option>
+                <option value="applied">applied</option>
+              </select>
+            </div>
+            <div style="min-width: 110px;">
+              <label>Limit</label>
+              <select id="cb_limit" data-ui="history_cb.select_limit" data-ib-pickkey="history_cb.select_limit" title="history.change_blocks.limit" style="width:100%;">
+                <option value="50" selected>50</option>
+                <option value="100">100</option>
+                <option value="200">200</option>
+                <option value="500">500</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="row" data-ui="history_cb.panel_actions" data-ib-pickkey="history_cb.panel_actions" title="history.change_blocks.actions">
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_refresh" class="btn_sm" data-ui="history_cb.btn_refresh" data-ib-pickkey="history_cb.btn_refresh" title="history.change_blocks.refresh">Refresh</button>
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_details" class="btn_sm" data-ui="history_cb.btn_details" data-ib-pickkey="history_cb.btn_details" title="history.change_blocks.details" disabled>Details</button>
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_preview_undo" class="btn_sm" data-ui="history_cb.btn_preview_undo" data-ib-pickkey="history_cb.btn_preview_undo" title="history.change_blocks.preview_undo" disabled>Undo Preview</button>
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_preview_repeat" class="btn_sm" data-ui="history_cb.btn_preview_repeat" data-ib-pickkey="history_cb.btn_preview_repeat" title="history.change_blocks.preview_repeat" disabled>Repeat Preview</button>
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_undo" class="btn_sm" data-ui="history_cb.btn_undo" data-ib-pickkey="history_cb.btn_undo" title="history.change_blocks.undo" disabled>Undo</button>
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button id="cb_repeat" class="btn_sm" data-ui="history_cb.btn_repeat" data-ib-pickkey="history_cb.btn_repeat" title="history.change_blocks.repeat" disabled>Repeat</button>
+            </div>
+            <div class="muted" id="cb_info" style="min-width: 320px; flex:1; padding-top: 6px;">-</div>
+          </div>
+
+          <div class="table_wrap" data-ui="history_cb_table.panel_wrap" data-ib-pickkey="history_cb_table.panel_wrap" title="history.change_blocks.table">
+            <div class="table_title">ChangeBlocks Liste</div>
+            <div class="table_head" data-ui="history_cb_table.panel_head" data-ib-pickkey="history_cb_table.panel_head" title="history.change_blocks.table.head">
+              <div class="muted">Preview zeigt Konflikte (strict). Bulk-Blocks koennen "blind" sein.</div>
+            </div>
+
+            <div class="table_box" id="cb_box" data-ui="history_cb_table.panel_box" data-ib-pickkey="history_cb_table.panel_box" title="history.change_blocks.table.box">
+              <table id="cb_tbl" class="ib_tbl" data-ui="history_cb.tbl" data-ib-pickkey="history_cb.tbl" title="history.change_blocks.table">
+                <thead>
+                  <tr>
+                    <th style="width: 34px;"><input type="checkbox" id="cb_sel_all" data-ui="history_cb.chk_select_all" data-ib-pickkey="history_cb.chk_select_all" title="history.change_blocks.select_all"/></th>
+                    <th style="width: 170px;">created_at</th>
+                    <th style="width: 260px;">block_id</th>
+                    <th style="width: 160px;">operation_source</th>
+                    <th style="width: 110px;">affected</th>
+                    <th style="width: 110px;">undo_status</th>
+                    <th style="width: 110px;">repeat_status</th>
+                    <th style="width: 140px;">conflict_status</th>
+                    <th>reason</th>
+                  </tr>
+                </thead>
+                <tbody id="cb_rows"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </details>
     </main>
   </div>
 
@@ -189,6 +279,233 @@
 
     let LIST = [];
     const SELECTED = new Set();
+
+    // ChangeBlocks UI (#404)
+    const $cbQ = document.getElementById('cb_q');
+    const $cbOp = document.getElementById('cb_op');
+    const $cbStatus = document.getElementById('cb_status');
+    const $cbLimit = document.getElementById('cb_limit');
+    const $cbRefresh = document.getElementById('cb_refresh');
+    const $cbDetails = document.getElementById('cb_details');
+    const $cbPreviewUndo = document.getElementById('cb_preview_undo');
+    const $cbPreviewRepeat = document.getElementById('cb_preview_repeat');
+    const $cbUndo = document.getElementById('cb_undo');
+    const $cbRepeat = document.getElementById('cb_repeat');
+    const $cbInfo = document.getElementById('cb_info');
+    const $cbRows = document.getElementById('cb_rows');
+    const $cbSelAll = document.getElementById('cb_sel_all');
+
+    let CB_LIST = [];
+    const CB_SELECTED = new Set();
+    const CB_PREVIEWS = new Map(); // block_id -> {undo,repeat}
+
+    function _cbPickSelectedOne(){
+      const a = Array.from(CB_SELECTED || []).filter(Boolean);
+      return a.length === 1 ? String(a[0]) : '';
+    }
+
+    function _cbApplyButtons(){
+      const one = _cbPickSelectedOne();
+      const on = !!one;
+      if($cbDetails) $cbDetails.disabled = !on;
+      if($cbPreviewUndo) $cbPreviewUndo.disabled = !on;
+      if($cbPreviewRepeat) $cbPreviewRepeat.disabled = !on;
+      if($cbUndo) $cbUndo.disabled = !on;
+      if($cbRepeat) $cbRepeat.disabled = !on;
+      if($cbInfo) $cbInfo.textContent = on ? ('Auswahl: ' + one) : ('Auswahl: -');
+    }
+
+    function _cbMatchesQuery(b, q){
+      const s = String(q || '').trim().toLowerCase();
+      if(!s) return true;
+      const ss = (b && b.series_summary) ? b.series_summary : {};
+      const parts = [
+        String(b && b.block_id || ''),
+        String(b && b.reason || ''),
+        String(b && b.operation_source || ''),
+        String(ss.measurement || ''),
+        String(ss.field || ''),
+        String(ss.entity_id || ''),
+        String(ss.friendly_name || ''),
+      ].join(' ').toLowerCase();
+      return parts.indexOf(s) >= 0;
+    }
+
+    function _cbConflictStatusFor(bid){
+      const p = CB_PREVIEWS.get(String(bid||'')) || {};
+      const u = p.undo || null;
+      const r = p.repeat || null;
+      function one(v){
+        try{ if(!v || !v.summary) return ''; }catch(e){ return ''; }
+        return v.summary.ok ? 'ok' : ('conflicts:' + String(v.summary.conflicts || 0));
+      }
+      const a = one(u);
+      const b = one(r);
+      if(!a && !b) return '-';
+      if(a && b) return 'undo:' + a + ' | rep:' + b;
+      return a ? ('undo:' + a) : ('rep:' + b);
+    }
+
+    function cbRender(){
+      if(!$cbRows) return;
+      $cbRows.innerHTML = '';
+      const q = String($cbQ && $cbQ.value ? $cbQ.value : '').trim();
+      const shown = (CB_LIST || []).filter(b => _cbMatchesQuery(b, q));
+      shown.forEach(b => {
+        const bid = String(b && b.block_id || '');
+        const tr = document.createElement('tr');
+        if(bid && CB_SELECTED.has(bid)) tr.classList.add('selected');
+
+        const tdSel = document.createElement('td');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = !!(bid && CB_SELECTED.has(bid));
+        cb.addEventListener('click', (ev)=>{ try{ ev.stopPropagation(); }catch(e){} });
+        cb.addEventListener('change', ()=>{
+          if(!bid) return;
+          if(cb.checked) CB_SELECTED.add(bid); else CB_SELECTED.delete(bid);
+          _cbApplyButtons();
+          cbRender();
+        });
+        tdSel.appendChild(cb);
+        tr.appendChild(tdSel);
+
+        const tdCreated = document.createElement('td');
+        tdCreated.textContent = fmtTs(b && b.created_at);
+        tr.appendChild(tdCreated);
+
+        const tdId = document.createElement('td');
+        tdId.textContent = bid;
+        tr.appendChild(tdId);
+
+        const tdOp = document.createElement('td');
+        tdOp.textContent = String(b && b.operation_source || '');
+        tr.appendChild(tdOp);
+
+        const tdAff = document.createElement('td');
+        tdAff.textContent = String(b && b.affected_count !== undefined ? b.affected_count : '');
+        tr.appendChild(tdAff);
+
+        const tdUs = document.createElement('td');
+        tdUs.textContent = String(b && b.undo_status || '');
+        tr.appendChild(tdUs);
+
+        const tdRs = document.createElement('td');
+        tdRs.textContent = String(b && b.repeat_status || '');
+        tr.appendChild(tdRs);
+
+        const tdCs = document.createElement('td');
+        tdCs.textContent = _cbConflictStatusFor(bid);
+        tr.appendChild(tdCs);
+
+        const tdReason = document.createElement('td');
+        tdReason.textContent = String(b && b.reason || '');
+        tr.appendChild(tdReason);
+
+        tr.addEventListener('click', ()=>{
+          if(!bid) return;
+          CB_SELECTED.clear();
+          CB_SELECTED.add(bid);
+          _cbApplyButtons();
+          cbRender();
+        });
+
+        $cbRows.appendChild(tr);
+      });
+      if($cbInfo) $cbInfo.textContent = `ChangeBlocks: ${shown.length}`;
+      _cbApplyButtons();
+    }
+
+    async function cbLoad(){
+      const lim = Number($cbLimit && $cbLimit.value ? $cbLimit.value : 50) || 50;
+      const op = String($cbOp && $cbOp.value ? $cbOp.value : '').trim();
+      const st = String($cbStatus && $cbStatus.value ? $cbStatus.value : '').trim();
+      const qs = new URLSearchParams();
+      qs.set('limit', String(lim));
+      if(op) qs.set('operation_source', op);
+      if(st) qs.set('status', st);
+      const j = await api('./api/change_blocks_v2' + (qs.toString() ? ('?' + qs.toString()) : ''));
+      CB_LIST = j.rows || [];
+      CB_SELECTED.clear();
+      cbRender();
+    }
+
+    function _cbHtmlEsc(s){
+      return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    async function cbShowDetails(){
+      const bid = _cbPickSelectedOne();
+      if(!bid) return;
+      const j = await api('./api/change_block?id=' + encodeURIComponent(bid));
+      const b = j.block || {};
+      const ss = b.series_summary || {};
+      const meta = b.meta || {};
+      const child = Array.isArray(meta.child_blocks) ? meta.child_blocks.map(x=>String(x||'').trim()).filter(Boolean) : [];
+      let html = '';
+      html += '<div style="font-size:12px;line-height:1.35;">';
+      html += '<div><b>block_id</b>: <code>' + _cbHtmlEsc(b.block_id) + '</code></div>';
+      html += '<div><b>created_at</b>: ' + _cbHtmlEsc(String(b.created_at||'')) + '</div>';
+      html += '<div><b>operation_source</b>: ' + _cbHtmlEsc(String(b.operation_source||'')) + '</div>';
+      html += '<div><b>reason</b>: ' + _cbHtmlEsc(String(b.reason||'')) + '</div>';
+      html += '<div><b>affected_count</b>: ' + _cbHtmlEsc(String(b.affected_count||'')) + '</div>';
+      html += '<div><b>status</b>: ' + _cbHtmlEsc(String(b.status||'')) + ' | <b>undo</b>: ' + _cbHtmlEsc(String(b.undo_status||'')) + ' | <b>repeat</b>: ' + _cbHtmlEsc(String(b.repeat_status||'')) + '</div>';
+      html += '<div style="margin-top:8px;"><b>series</b>: ' + _cbHtmlEsc([ss.measurement, ss.field, ss.entity_id, ss.friendly_name].filter(Boolean).join(' | ')) + '</div>';
+      if(child.length){
+        html += '<div style="margin-top:8px;"><b>child_blocks</b> (' + String(child.length) + '):</div>';
+        html += '<div class="mono" style="white-space:pre-wrap;">' + _cbHtmlEsc(child.join('\n')) + '</div>';
+      }
+      html += '</div>';
+
+      const actions = [
+        { label:'Undo Preview', onClick: ()=>{ cbPreview('undo').catch(e=>err(String(e.message||e))); } },
+        { label:'Repeat Preview', onClick: ()=>{ cbPreview('repeat').catch(e=>err(String(e.message||e))); } },
+      ];
+      if(window.InfluxBroPopup && window.InfluxBroPopup.show){
+        window.InfluxBroPopup.show('ChangeBlock Details', html, { bodyHtml:true, actions });
+      }else{
+        alert('ChangeBlock: ' + bid);
+      }
+    }
+
+    async function cbPreview(direction){
+      const bid = _cbPickSelectedOne();
+      if(!bid) return;
+      const dir = String(direction||'').trim().toLowerCase();
+      const j = await api('./api/change_block/validate', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ id: bid, direction: dir })});
+      const v = j.validation || {};
+      const p = CB_PREVIEWS.get(bid) || {};
+      if(dir === 'undo') p.undo = v;
+      else p.repeat = v;
+      CB_PREVIEWS.set(bid, p);
+      cbRender();
+
+      try{
+        const s = v.summary || {};
+        const msg = (dir.toUpperCase() + ' Preview') + '\n' +
+          'ok=' + String(!!s.ok) + ' total=' + String(s.total||0) +
+          ' ok=' + String(s.ok_count||0) +
+          ' already=' + String(s.already_applied||0) +
+          ' conflicts=' + String(s.conflicts||0);
+        if(window.InfluxBroPopup && window.InfluxBroPopup.show){
+          window.InfluxBroPopup.show('Preview: ' + dir, msg, { copyText: JSON.stringify(v, null, 2) });
+        }else{
+          ok(msg);
+        }
+      }catch(e){}
+    }
+
+    async function cbDo(action){
+      const bid = _cbPickSelectedOne();
+      if(!bid) return;
+      const a = String(action||'').trim().toLowerCase();
+      const m = (a === 'undo') ? 'Undo wirklich ausfuehren?' : 'Repeat wirklich ausfuehren?';
+      if(!confirm(m + '\n\nChangeBlock: ' + bid)) return;
+      const ep = (a === 'undo') ? './api/change_block/undo' : './api/change_block/repeat';
+      await api(ep, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ id: bid, confirm:true })});
+      ok(a.toUpperCase() + ' ausgefuehrt.');
+      await cbLoad();
+    }
 
     function err(s){ $err.textContent = s || ''; if(s) { try{ alert(s); }catch(e){} } }
     function ok(s){ $ok.textContent = s || ''; }
@@ -365,7 +682,25 @@
     $rollbackSelected.addEventListener('click', (ev)=>{ ev.preventDefault(); ev.stopPropagation(); rollbackIds(Array.from(SELECTED)).catch(e=>err(String(e.message||e))); });
     $rollbackPreset.addEventListener('click', (ev)=>{ ev.preventDefault(); ev.stopPropagation(); rollbackPreset($preset.value).catch(e=>err(String(e.message||e))); });
 
+    if($cbRefresh) $cbRefresh.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbLoad().catch(e=>err(String(e.message||e))); });
+    if($cbDetails) $cbDetails.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbShowDetails().catch(e=>err(String(e.message||e))); });
+    if($cbPreviewUndo) $cbPreviewUndo.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbPreview('undo').catch(e=>err(String(e.message||e))); });
+    if($cbPreviewRepeat) $cbPreviewRepeat.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbPreview('repeat').catch(e=>err(String(e.message||e))); });
+    if($cbUndo) $cbUndo.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbDo('undo').catch(e=>err(String(e.message||e))); });
+    if($cbRepeat) $cbRepeat.addEventListener('click', (ev)=>{ try{ ev.preventDefault(); ev.stopPropagation(); }catch(e){} cbDo('repeat').catch(e=>err(String(e.message||e))); });
+    if($cbSelAll) $cbSelAll.addEventListener('change', ()=>{
+      const on = !!$cbSelAll.checked;
+      const ids = (CB_LIST || []).map(b=>String(b && b.block_id || '')).filter(Boolean);
+      if(on) ids.forEach(id=>CB_SELECTED.add(id)); else ids.forEach(id=>CB_SELECTED.delete(id));
+      cbRender();
+    });
+    if($cbQ) $cbQ.addEventListener('input', ()=>cbRender());
+    if($cbOp) $cbOp.addEventListener('change', ()=>cbLoad().catch(()=>{}));
+    if($cbStatus) $cbStatus.addEventListener('change', ()=>cbLoad().catch(()=>{}));
+    if($cbLimit) $cbLimit.addEventListener('change', ()=>cbLoad().catch(()=>{}));
+
     load().catch(()=>{});
+    cbLoad().catch(()=>{});
   </script>
 
   {% include "_table_cols.html" %}

--- a/influxbro/app/templates/import.html
+++ b/influxbro/app/templates/import.html
@@ -605,8 +605,9 @@
         try{ window.InfluxBroStatus && window.InfluxBroStatus.start && window.InfluxBroStatus.start('import.run', 'Import laeuft...'); }catch(e){}
         try{
           const j = await api('./api/import_start', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
-          $runHint.textContent = `Importiert: ${j.imported}`;
-          ok(j.message || 'Import fertig.');
+          const bid = String(j.change_block_id || '').trim();
+          $runHint.textContent = `Importiert: ${j.imported}` + (bid ? ` | ChangeBlock: ${bid}` : '');
+          ok((j.message || 'Import fertig.') + (bid ? `\nChangeBlock: ${bid}` : ''));
           try{ window.InfluxBroStatus && window.InfluxBroStatus.done && window.InfluxBroStatus.done('import.run', j.message || 'Import fertig.'); }catch(e){}
         }catch(e){
           const s = String(e && e.message ? e.message : e);

--- a/influxbro/app/templates/index.html
+++ b/influxbro/app/templates/index.html
@@ -1808,20 +1808,20 @@ function _applyOverlays(){
             showscale: false,
             hovertemplate: '%{x}<br>abs(d/dt)=%{z}<extra></extra>',
           }];
-          const layout = {
-            margin: {l: 52, r: 10, t: 2, b: 18},
-            height: 60,
-            xaxis: {
-              type:'date',
-              showgrid:false,
-              zeroline:false,
-              showticklabels:false,
-              fixedrange: true,
-              autorange: !(winLo !== null && winHi !== null),
-              range: (winLo !== null && winHi !== null) ? [new Date(winLo), new Date(winHi)] : undefined,
-            },
-            yaxis: {showticklabels:false, showgrid:false, zeroline:false},
-          };
+           const layout = _ibPlotlyTheme({
+             margin: {l: 52, r: 10, t: 2, b: 18},
+             height: 60,
+             xaxis: {
+               type:'date',
+               showgrid:false,
+               zeroline:false,
+               showticklabels:false,
+               fixedrange: true,
+               autorange: !(winLo !== null && winHi !== null),
+               range: (winLo !== null && winHi !== null) ? [new Date(winLo), new Date(winHi)] : undefined,
+             },
+             yaxis: {showticklabels:false, showgrid:false, zeroline:false},
+           });
           try{ window.Plotly.react($derivStripPlot, data, layout, {displayModeBar:false, responsive:true, staticPlot:true}); }catch(e){}
         }
       }
@@ -1874,7 +1874,7 @@ function _applyOverlays(){
             hovertemplate: '%{x|%d.%m.%y %H:%M:%S.%L}<br>Outlier d/dt=%{y}<extra></extra>',
           });
         }
-        const layout = {
+        const layout = _ibPlotlyTheme({
           margin: {l: 52, r: 10, t: 6, b: 64},
           height: 140,
           xaxis: {
@@ -1886,7 +1886,7 @@ function _applyOverlays(){
           yaxis: {automargin:true, title: (wantSigned ? 'd/dt' : 'abs(d/dt)'), fixedrange: true},
           showlegend: true,
           legend: {orientation: 'h', x: 0, xanchor: 'left', y: -0.35, yanchor: 'top', font: {size: 11}},
-        };
+        });
         try{ window.Plotly.react($derivGraphPlot, data, layout, {displayModeBar:false, responsive:true, staticPlot:true}); }catch(e){}
       }
     }
@@ -1905,6 +1905,43 @@ function _zoomScale(){
   }catch(e){
     return 1;
   }
+}
+
+function _ibCssVar(name, fallback){
+  try{
+    const v = getComputedStyle(document.documentElement).getPropertyValue(String(name||'')).trim();
+    return v || String(fallback||'');
+  }catch(e){
+    return String(fallback||'');
+  }
+}
+
+function _ibPlotlyTheme(layout){
+  // Keep Plotly readable across themes (#405).
+  const l = (layout && typeof layout === 'object') ? layout : {};
+  const bg = _ibCssVar('--ib-surface', '#ffffff') || '#ffffff';
+  const fg = _ibCssVar('--ib-text', '#111827') || '#111827';
+  const grid = _ibCssVar('--ib-border', '#d7dce2') || '#d7dce2';
+  const font = Object.assign({ color: fg }, (l.font && typeof l.font === 'object') ? l.font : {});
+  function patchAxis(ax){
+    const a = (ax && typeof ax === 'object') ? ax : {};
+    const tickfont = Object.assign({ color: fg }, (a.tickfont && typeof a.tickfont === 'object') ? a.tickfont : {});
+    const titlefont = Object.assign({ color: fg }, (a.titlefont && typeof a.titlefont === 'object') ? a.titlefont : {});
+    return Object.assign({
+      gridcolor: a.gridcolor !== undefined ? a.gridcolor : grid,
+      zerolinecolor: a.zerolinecolor !== undefined ? a.zerolinecolor : grid,
+      linecolor: a.linecolor !== undefined ? a.linecolor : grid,
+      tickfont,
+      titlefont,
+    }, a);
+  }
+  return Object.assign({
+    paper_bgcolor: l.paper_bgcolor !== undefined ? l.paper_bgcolor : bg,
+    plot_bgcolor: l.plot_bgcolor !== undefined ? l.plot_bgcolor : bg,
+    font,
+    xaxis: patchAxis(l.xaxis),
+    yaxis: patchAxis(l.yaxis),
+  }, l);
 }
 
 function _rawVisibleBoundsMs(){
@@ -2076,16 +2113,16 @@ async function refreshGraphContext(opts){
 
       const sc = _zoomScale();
       const baseH = (GRAPH_CTX_H_PX && isFinite(GRAPH_CTX_H_PX)) ? Math.round(GRAPH_CTX_H_PX) : 180;
-      const layout = {
-        margin: { l: 52, r: 10, t: 10, b: 42 },
-        height: Math.round(baseH * sc),
-        autosize: true,
-        xaxis: { type: 'date', fixedrange: true },
-        yaxis: { automargin: true, fixedrange: true },
-        shapes,
-        showlegend: true,
-        legend: {orientation: 'h', x: 0, xanchor: 'left', y: -0.25, yanchor: 'top', font: {size: 11}},
-      };
+       const layout = _ibPlotlyTheme({
+         margin: { l: 52, r: 10, t: 10, b: 42 },
+         height: Math.round(baseH * sc),
+         autosize: true,
+         xaxis: { type: 'date', fixedrange: true },
+         yaxis: { automargin: true, fixedrange: true },
+         shapes,
+         showlegend: true,
+         legend: {orientation: 'h', x: 0, xanchor: 'left', y: -0.25, yanchor: 'top', font: {size: 11}},
+       });
 
       if(force){
         try{ window.Plotly.purge($graphCtxPlot); }catch(e){}
@@ -13261,7 +13298,7 @@ async function refreshEditGraph(){
       }
     }
   }catch(e){}
-  const layout = {
+  const layout = _ibPlotlyTheme({
     margin: {l: 48, r: 12, t: 10, b: 36},
     height: 320,
     xaxis: {
@@ -13274,7 +13311,7 @@ async function refreshEditGraph(){
     yaxis: {title: ''},
     showlegend: true,
     legend: {orientation: 'h'},
-  };
+  });
   try{
     if(window.Plotly && $editGraphPlot){
       await window.Plotly.newPlot($editGraphPlot, traces, layout, {displayModeBar: false, responsive: true});

--- a/influxbro/app/templates/restore.html
+++ b/influxbro/app/templates/restore.html
@@ -1046,21 +1046,22 @@
            FULLRESTORE_JOB_ID = String(started.job_id || '');
            if(!FULLRESTORE_JOB_ID) throw new Error('fullrestore job_id missing');
 
-           while(true){
-             const j = await api('./api/fullrestore_job/status?job_id=' + encodeURIComponent(FULLRESTORE_JOB_ID));
-             const st = j.status || {};
-             const msg = String(st.message || 'FullRestore laeuft...');
-             const applied = Number(st.applied || 0);
-             const read = Number(st.read_lines || 0);
-             const detail = [msg, (read ? ('Zeilen: ' + read) : ''), (applied ? ('applied: ' + applied) : '')].filter(Boolean).join(' | ');
-             try{ if($fullRestoreStatusTxt) $fullRestoreStatusTxt.textContent = detail; }catch(e){}
+            while(true){
+              const j = await api('./api/fullrestore_job/status?job_id=' + encodeURIComponent(FULLRESTORE_JOB_ID));
+              const st = j.status || {};
+              const msg = String(st.message || 'FullRestore laeuft...');
+              const applied = Number(st.applied || 0);
+              const read = Number(st.read_lines || 0);
+              const bid = String(st.change_block_id || '').trim();
+              const detail = [msg, (read ? ('Zeilen: ' + read) : ''), (applied ? ('applied: ' + applied) : '')].filter(Boolean).join(' | ');
+              try{ if($fullRestoreStatusTxt) $fullRestoreStatusTxt.textContent = detail; }catch(e){}
 
              const state = String(st.state || '');
-             if(state === 'done'){
-               ok('FullRestore fertig. applied=' + String(st.applied || 0));
-               stopFullRestoreUi(true, 'Fertig.');
-               return;
-             }
+              if(state === 'done'){
+                ok('FullRestore fertig. applied=' + String(st.applied || 0) + (bid ? ('\nChangeBlock: ' + bid) : ''));
+                stopFullRestoreUi(true, 'Fertig.');
+                return;
+              }
              if(state === 'cancelled'){
                ok('Abgebrochen.');
                stopFullRestoreUi(true, 'Abgebrochen.');
@@ -1556,8 +1557,8 @@
          }
 
          // Poll until done/error
-         while(true){
-           let st;
+          while(true){
+            let st;
            try{
              st = await pollOnce();
            }catch(e){
@@ -1577,6 +1578,10 @@
            }catch(e){}
 
             setRunStatusText(String(st.message || 'Restore laeuft...'));
+            try{
+              const bid = String(st.change_block_id || '').trim();
+              if(bid) RUN_CTX.change_block_id = bid;
+            }catch(e){}
             try{
               const pct = RUN_CTX && RUN_CTX.pct ? (' | ' + RUN_CTX.pct) : '';
               window.InfluxBroStatus && window.InfluxBroStatus.progress && window.InfluxBroStatus.progress(statusKey, String(st.message || 'Restore laeuft...') + pct);
@@ -1611,11 +1616,12 @@
            throw new Error('restore result not ready');
          }
 
-         const applied = Number(res.applied || 0);
-         const skipped = Number(res.skipped || 0);
-          ok(`Restore fertig. (applied=${applied}, skipped=${skipped})`);
-          setRunStatusText(`Fertig (applied=${applied}, skipped=${skipped}).`);
-          try{ window.InfluxBroStatus && window.InfluxBroStatus.done && window.InfluxBroStatus.done(statusKey, `Restore fertig (applied=${applied}, skipped=${skipped}).`); }catch(e){}
+          const applied = Number(res.applied || 0);
+          const skipped = Number(res.skipped || 0);
+          const bid = String((RUN_CTX && RUN_CTX.change_block_id) || '').trim();
+           ok(`Restore fertig. (applied=${applied}, skipped=${skipped})` + (bid ? `\nChangeBlock: ${bid}` : ''));
+           setRunStatusText(`Fertig (applied=${applied}, skipped=${skipped}).`);
+           try{ window.InfluxBroStatus && window.InfluxBroStatus.done && window.InfluxBroStatus.done(statusKey, `Restore fertig (applied=${applied}, skipped=${skipped}).`); }catch(e){}
 
          try{
            if($runDetails){

--- a/influxbro/app/undo_manager.py
+++ b/influxbro/app/undo_manager.py
@@ -128,6 +128,16 @@ class UndoManager:
             locked = not self._compatible
             undo_count = len(self._undo)
             redo_count = len(self._redo)
+
+            def _undo_supported(a: dict[str, Any] | None) -> bool:
+                if not a or not isinstance(a, dict):
+                    return False
+                meta = a.get("meta") if isinstance(a.get("meta"), dict) else {}
+                # default True
+                if meta.get("undo_supported") is False:
+                    return False
+                return True
+
             return UndoStatus(
                 ok=True,
                 compatible=bool(self._compatible),
@@ -135,7 +145,7 @@ class UndoManager:
                 locked_reason=str(self._locked_reason or ""),
                 undo_count=undo_count,
                 repeat_count=redo_count,
-                undo_available=bool(undo_count > 0 and not locked),
+                undo_available=bool(undo_count > 0 and not locked and _undo_supported(self._undo[-1] if self._undo else None)),
                 repeat_available=bool(redo_count > 0 and not locked),
                 last_undo_action=self._undo[-1] if self._undo else None,
                 last_repeat_action=self._redo[-1] if self._redo else None,

--- a/influxbro/app/undo_manager.py
+++ b/influxbro/app/undo_manager.py
@@ -17,6 +17,13 @@ def _looks_like_row(row: object) -> bool:
     return bool(row.get("_time")) and bool(row.get("_measurement")) and bool(row.get("_field"))
 
 
+def _has_change_block_ref(meta: object) -> bool:
+    if not isinstance(meta, dict):
+        return False
+    bid = str(meta.get("change_block_id") or "").strip()
+    return bool(bid)
+
+
 @dataclass
 class UndoStatus:
     ok: bool
@@ -85,8 +92,14 @@ class UndoManager:
                     after_rows = it.get("after_rows")
                     if not isinstance(before_rows, list) or not isinstance(after_rows, list):
                         raise ValueError("before_rows/after_rows must be lists")
-                    if any(not _looks_like_row(r) for r in before_rows + after_rows):
-                        raise ValueError("invalid row shape")
+                    meta = it.get("meta")
+                    if before_rows or after_rows:
+                        if any(not _looks_like_row(r) for r in before_rows + after_rows):
+                            raise ValueError("invalid row shape")
+                    else:
+                        # Allow ref-only entries that point at a persisted ChangeBlock.
+                        if not _has_change_block_ref(meta):
+                            raise ValueError("empty action without change_block_id")
                 self._undo = undo
                 self._redo = redo
             except Exception as e:
@@ -164,7 +177,8 @@ class UndoManager:
 
             before_rows = [r for r in (before_rows or []) if _looks_like_row(r)]
             after_rows = [r for r in (after_rows or []) if _looks_like_row(r)]
-            if not before_rows and not after_rows:
+            meta = meta or {}
+            if not before_rows and not after_rows and not _has_change_block_ref(meta):
                 raise ValueError("empty action")
 
             action = {
@@ -180,7 +194,7 @@ class UndoManager:
                 "label": str(group_label or ""),
                 "before_rows": before_rows,
                 "after_rows": after_rows,
-                "meta": meta or {},
+                "meta": meta,
             }
 
             self._undo.append(action)

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.452"
+version: "1.12.453"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.450"
+version: "1.12.451"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.449"
+version: "1.12.450"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.448"
+version: "1.12.449"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.451"
+version: "1.12.452"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Enforces Change-Service for write operations (InfluxDB v2-only) and adds bulk/range ChangeBlocks execution via child blocks.
- Extends History with a ChangeBlocks UI including per-item details and undo/repeat previews with conflict visibility.
- Adds an MVP theme system (mode + accent) with instant apply.

## Issues
- Closes #400
- Closes #403
- Closes #404
- Closes #405

## Notes
- `pytest` is not available in this environment; verified via `python3 -m py_compile` and a code-scan for direct writes.
- #406 is an epic; this PR addresses its prerequisites only.