### PR TITLE
feat(dq): add orphans view for ha_missing findings (#406)

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.12.455
+
+### Enhancement
+
+- Datenpflege (DQ): neue API `/api/dq/orphans` und UI-Karte "Verwaiste Messwerte (HA fehlt)" basierend auf dem letzten DQ-Lauf (Finding `ha_missing`). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.454
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -23695,6 +23695,77 @@ def api_dq_quality_runs_list():
     return jsonify({"ok": True, "runs": _dq_runs_list(limit)})
 
 
+@app.get("/api/dq/orphans")
+def api_dq_orphans():
+    """List orphan candidates (series with ha_missing) from a DQ quality run.
+
+    This is a lightweight view for Epic #406 (Module: Verwaiste Messwerte).
+    """
+
+    rid = str(request.args.get("run_id") or "").strip()
+    try:
+        limit = int(request.args.get("limit") or 200)
+    except Exception:
+        limit = 200
+    limit = max(1, min(2000, limit))
+
+    if not rid:
+        # Prefer latest done run.
+        for r in _dq_runs_list(50):
+            if isinstance(r, dict) and str(r.get("state") or "") == "done" and str(r.get("id") or ""):
+                rid = str(r.get("id") or "")
+                break
+
+    if not rid:
+        return jsonify({"ok": True, "run_id": None, "orphans": [], "total": 0, "error": "no dq run found"})
+
+    run = _dq_run_load(rid)
+    if not run:
+        return jsonify({"ok": False, "error": "run not found"}), 404
+
+    items = run.get("items") if isinstance(run.get("items"), list) else []
+    out: list[dict[str, Any]] = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        eid = str(it.get("entity_id") or "").strip()
+        if not eid:
+            continue
+        findings = it.get("findings") if isinstance(it.get("findings"), list) else []
+        ha_missing = next((f for f in findings if isinstance(f, dict) and str(f.get("kind") or "") == "ha_missing"), None)
+        if not ha_missing:
+            continue
+        ha_err = None
+        try:
+            ev = ha_missing.get("evidence") if isinstance(ha_missing.get("evidence"), dict) else {}
+            ha_err = ev.get("error")
+        except Exception:
+            ha_err = None
+        stats = it.get("stats") if isinstance(it.get("stats"), dict) else {}
+        out.append({
+            "series_key": it.get("series_key"),
+            "measurement": it.get("measurement"),
+            "field": it.get("field"),
+            "entity_id": eid,
+            "friendly_name": it.get("friendly_name"),
+            "newest_time": stats.get("newest_time"),
+            "score": it.get("score"),
+            "status": it.get("status"),
+            "ha_error": ha_err,
+            "recommendations": it.get("recommendations"),
+        })
+        if len(out) >= limit:
+            break
+
+    return jsonify({
+        "ok": True,
+        "run_id": rid,
+        "run_state": run.get("state"),
+        "orphans": out,
+        "total": len(out),
+    })
+
+
 @app.get("/api/dq/quality_run/export")
 def api_dq_quality_run_export():
     rid = str(request.args.get("id") or "").strip()

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -94,6 +94,31 @@
         </div>
       </div>
 
+      <div class="card" data-ui="dq_orphans.panel_card" data-ib-pickkey="dq_orphans.panel_card" title="dq.orphans">
+        <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
+          <div style="font-weight:900; font-size:16px;" data-ui="dq_orphans.txt_title" data-ib-pickkey="dq_orphans.txt_title" title="dq.orphans.title">Verwaiste Messwerte (HA fehlt)</div>
+          <div class="muted" id="orph_meta" data-ui="dq_orphans.txt_meta" data-ib-pickkey="dq_orphans.txt_meta" title="dq.orphans.meta"></div>
+        </div>
+        <div class="muted">Zeigt Serien aus dem letzten DQ-Lauf, bei denen die HA Metadaten nicht verfuegbar waren (Finding: `ha_missing`).</div>
+        <div class="row" data-ui="dq_orphans.panel_controls" data-ib-pickkey="dq_orphans.panel_controls" title="dq.orphans.controls">
+          <div style="min-width: 160px;">
+            <label>Limit</label>
+            <input id="orph_limit" type="number" min="1" max="2000" value="200" data-ui="dq_orphans.input_limit" data-ib-pickkey="dq_orphans.input_limit" title="dq.orphans.limit" />
+          </div>
+          <button id="orph_reload" class="btn_sm" data-ui="dq_orphans.btn_reload" data-ib-pickkey="dq_orphans.btn_reload" title="dq.orphans.reload">Aus aktivem Lauf laden</button>
+        </div>
+        <div class="table_wrap" data-ui="dq_orphans.panel_table" data-ib-pickkey="dq_orphans.panel_table" title="dq.orphans.table">
+          <div class="table_box" style="max-height:42vh;">
+            <table id="dq_orph_tbl" data-ui="dq_orphans.tbl" data-ib-pickkey="dq_orphans.tbl" title="dq.orphans.tbl">
+              <thead>
+                <tr><th>Entity</th><th>Messwert</th><th>Newest</th><th>HA Fehler</th><th>Empfehlung</th></tr>
+              </thead>
+              <tbody id="orph_rows"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
       <div class="card" data-ui="dq_proposals.panel_card" data-ib-pickkey="dq_proposals.panel_card" title="dq.proposals">
         <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
           <div style="font-weight:900; font-size:16px;" data-ui="dq_proposals.txt_title" data-ib-pickkey="dq_proposals.txt_title" title="dq.proposals.title">Repair Proposals (Phase 2, Preview-only)</div>
@@ -239,6 +264,11 @@
       const $haGen = document.getElementById('dq_ha_gen');
       const $haReload = document.getElementById('dq_ha_reload');
       const $haRows = document.getElementById('dq_ha_rows');
+
+      const $orphMeta = document.getElementById('orph_meta');
+      const $orphLimit = document.getElementById('orph_limit');
+      const $orphReload = document.getElementById('orph_reload');
+      const $orphRows = document.getElementById('orph_rows');
 
       let ACTIVE_RUN_ID = null;
       let ACTIVE_RUN = null;
@@ -597,6 +627,34 @@
         await loadHAProposals();
       }
 
+      async function loadOrphans(){
+        let lim = 200;
+        try{ lim = Number($orphLimit && $orphLimit.value ? $orphLimit.value : 200) || 200; }catch(e){ lim = 200; }
+        lim = Math.max(1, Math.min(2000, lim));
+        const qs = new URLSearchParams();
+        qs.set('limit', String(lim));
+        if(ACTIVE_RUN_ID) qs.set('run_id', String(ACTIVE_RUN_ID));
+
+        let j;
+        try{
+          j = await api('./api/dq/orphans?' + qs.toString());
+        }catch(e){
+          try{ if($orphMeta) $orphMeta.textContent = ''; }catch(x){}
+          throw e;
+        }
+
+        const xs = Array.isArray(j.orphans) ? j.orphans : [];
+        try{ if($orphRows) $orphRows.innerHTML = ''; }catch(e){}
+        xs.forEach(it => {
+          const tr = document.createElement('tr');
+          const meas = String(it.measurement||'') + '/' + String(it.field||'');
+          const rec = Array.isArray(it.recommendations) ? it.recommendations.slice(0,2).join(' | ') : '';
+          tr.innerHTML = `<td class="mono">${String(it.entity_id||'')}</td><td class="mono">${meas}</td><td class="mono">${String(it.newest_time||'')}</td><td>${String(it.ha_error||'')}</td><td>${rec}</td>`;
+          try{ if($orphRows) $orphRows.appendChild(tr); }catch(e){}
+        });
+        try{ if($orphMeta) $orphMeta.textContent = `Run ${String(j.run_id||'-')} | Orphans ${xs.length}`; }catch(e){}
+      }
+
       async function pollRun(runId){
         let j;
         try{
@@ -613,6 +671,7 @@
           renderRun(run);
           try{ loadProposals().catch(()=>{}); }catch(e){}
           try{ loadHAProposals().catch(()=>{}); }catch(e){}
+          try{ if(st === 'done') loadOrphans().catch(()=>{}); }catch(e){}
           if(st === 'done') ok('Analyse abgeschlossen.');
           else err('Analyse Fehler: ' + String(run.error||''));
           return;
@@ -698,6 +757,8 @@
 
       try{ if($haGen) $haGen.onclick = ()=>{ generateHAProposals().catch(()=>{}); }; }catch(e){}
       try{ if($haReload) $haReload.onclick = ()=>{ loadHAProposals().catch(()=>{}); }; }catch(e){}
+
+      try{ if($orphReload) $orphReload.onclick = ()=>{ loadOrphans().catch(e=>err('Orphans: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
 
       try{ loadHAProposals().catch(()=>{}); }catch(e){}
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.454"
+version: "1.12.455"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Fuegt `/api/dq/orphans` hinzu: liefert eine kompakte Liste von Serien aus dem letzten DQ-Lauf mit Finding `ha_missing`.
- Ergaenzt die DQ UI (`/dq`) um eine Karte "Verwaiste Messwerte (HA fehlt)" inkl. Reload und Limit.

## Kontext
- Teil von Epic #406 (Modul: Verwaiste Messwerte).
- Nutzt vorhandene DQ-Run Persistenz unter `/data/dq/quality_runs`.

## QA
- `python3 -m py_compile influxbro/app/app.py`
- Lokaler Smoke-Test: `/dq` 200, `/api/dq/orphans` 200 (ohne Runs: leere Liste).