### PR TITLE
feat(dq): add merge candidates view for renames (#406)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,93 @@
 - Home Assistant Core Version abfragen:
   - `curl -s -H "Authorization: Bearer $SUPERVISOR_TOKEN" http://192.168.2.200:8123/api/config | jq -r '.version'`
 
+## Live-System Tests (Version Check + Update via Playwright)
+
+Wenn Tests gegen das Live-System (Home Assistant Ingress) ausgefuehrt werden, MUSS vor dem Testlauf der Versionsstand von InfluxBro geprueft werden.
+
+Pflichtablauf:
+
+1. Erwartete Version bestimmen
+
+- Quelle: `influxbro/config.yaml` -> `version` (Repo-Stand).
+
+2. Live-Version pruefen
+
+- InfluxBro Web UI oeffnen (Ingress).
+- `GET ./api/info` (same-origin) ausfuehren und `version` vergleichen.
+
+3. Wenn Version nicht korrekt ist: Update automatisieren
+
+- Falls Live-Version != erwartete Version, MUSS per Playwright die Aktualisierung auf das neueste InfluxBro Release/Update im Home Assistant UI ausgefuehrt werden.
+- Danach Add-on neu starten (falls HA UI das nicht automatisch macht) und Version erneut via `./api/info` verifizieren.
+
+### Playwright Anweisung (Beispiel)
+
+Voraussetzungen (als Env-Variablen):
+
+- `HA_URL` (z.B. `http://192.168.2.200:8123`)
+- `HA_USERNAME`
+- `HA_PASSWORD`
+- `INFLUXBRO_EXPECT_VERSION` (z.B. `1.12.456`)
+
+Playwright Test-Skript (Snippet, best-effort):
+
+```ts
+// playwright/influxbro-update.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('update InfluxBro if version mismatches', async ({ page }) => {
+  const HA_URL = process.env.HA_URL!
+  const USER = process.env.HA_USERNAME!
+  const PASS = process.env.HA_PASSWORD!
+  const EXPECT = process.env.INFLUXBRO_EXPECT_VERSION!
+
+  await page.goto(HA_URL, { waitUntil: 'domcontentloaded' })
+
+  // Login (works for fresh sessions; already-logged-in is fine)
+  if (await page.getByLabel('Username').isVisible().catch(() => false)) {
+    await page.getByLabel('Username').fill(USER)
+    await page.getByLabel('Password').fill(PASS)
+    await page.getByRole('button', { name: /log in/i }).click()
+  }
+
+  // Open Add-ons
+  await page.goto(`${HA_URL}/hassio/dashboard`, { waitUntil: 'domcontentloaded' })
+  await page.getByRole('link', { name: /add-ons/i }).click().catch(() => {})
+  await page.getByText('InfluxBro', { exact: false }).click()
+
+  // If an Update button is present, click it
+  const updateBtn = page.getByRole('button', { name: /^update$/i })
+  if (await updateBtn.isVisible().catch(() => false)) {
+    await updateBtn.click()
+    // Wait for update to finish (best-effort: wait until Update disappears)
+    await expect(updateBtn).toBeHidden({ timeout: 10 * 60 * 1000 })
+  }
+
+  // Start/Restart add-on (best-effort)
+  const startBtn = page.getByRole('button', { name: /^start$/i })
+  if (await startBtn.isVisible().catch(() => false)) {
+    await startBtn.click()
+  }
+
+  // Open Web UI and verify version via /api/info
+  await page.getByRole('button', { name: /open web ui/i }).click()
+  const popup = await page.waitForEvent('popup')
+  await popup.waitForLoadState('domcontentloaded')
+
+  const liveVer = await popup.evaluate(async () => {
+    const r = await fetch('./api/info')
+    const j = await r.json().catch(() => ({}))
+    return String((j && j.version) || '')
+  })
+  expect(liveVer).toBe(EXPECT)
+})
+```
+
+Hinweis:
+
+- Selektoren in HA koennen je nach Version variieren. Wenn die Automation scheitert, Testlauf abbrechen und manuell updaten (oder Selektoren anpassen) bevor Live-Tests fortgesetzt werden.
+
 ## UI-Komponenten-Entfernung (Tombstones Pflichtprozess)
 
 Beim Entfernen von UI-Komponenten (HTML, JS, CSS, Backend-Funktionen) muss zwingend ein nachvollziehbarer "Tombstone" hinterlassen werden.

--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Datenpflege (DQ): neue API `/api/dq/orphans` und UI-Karte "Verwaiste Messwerte (HA fehlt)" basierend auf dem letzten DQ-Lauf (Finding `ha_missing`). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
 
+## 1.12.456
+
+### Enhancement
+
+- Datenpflege (DQ): neue API `/api/dq/merge_candidates` und UI-Karte "Zusammenfuehren (Kandidaten)" fuer Umbenennungs-/Merge-Hinweise (gleicher `friendly_name`, aber HA fehlt vs. HA ok). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.454
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -23766,6 +23766,128 @@ def api_dq_orphans():
     })
 
 
+@app.get("/api/dq/merge_candidates")
+def api_dq_merge_candidates():
+    """Suggest merge candidates for entity_id renames (best-effort).
+
+    Heuristic:
+    - within one DQ run, find pairs with same measurement+field+friendly_name
+    - one side HA available, other side HA missing
+
+    This is a supporting view for Epic #406 (Module: Zusammenfuehren).
+    """
+
+    rid = str(request.args.get("run_id") or "").strip()
+    try:
+        limit = int(request.args.get("limit") or 200)
+    except Exception:
+        limit = 200
+    limit = max(1, min(2000, limit))
+
+    if not rid:
+        for r in _dq_runs_list(50):
+            if isinstance(r, dict) and str(r.get("state") or "") == "done" and str(r.get("id") or ""):
+                rid = str(r.get("id") or "")
+                break
+
+    if not rid:
+        return jsonify({"ok": True, "run_id": None, "candidates": [], "total": 0, "error": "no dq run found"})
+
+    run = _dq_run_load(rid)
+    if not run:
+        return jsonify({"ok": False, "error": "run not found"}), 404
+
+    items = run.get("items") if isinstance(run.get("items"), list) else []
+
+    def _ha_av(it: dict[str, Any]) -> bool:
+        try:
+            ha = it.get("ha") if isinstance(it.get("ha"), dict) else {}
+            return bool(ha.get("available"))
+        except Exception:
+            return False
+
+    # Key by (measurement, field, friendly_name)
+    by_key: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        m = str(it.get("measurement") or "").strip()
+        f = str(it.get("field") or "").strip()
+        fn = str(it.get("friendly_name") or "").strip()
+        eid = str(it.get("entity_id") or "").strip()
+        if not m or not f or not fn or not eid:
+            continue
+        by_key.setdefault((m, f, fn), []).append(it)
+
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for (m, f, fn), xs in by_key.items():
+        if len(xs) < 2:
+            continue
+        av = [x for x in xs if _ha_av(x)]
+        miss = [x for x in xs if not _ha_av(x)]
+        if not av or not miss:
+            continue
+
+        # Prefer highest score target among HA-available.
+        av.sort(key=lambda x: int(x.get("score") or 0), reverse=True)
+        tgt = av[0]
+
+        # Collect sources (ha_missing) as candidates.
+        for src in miss:
+            src_e = str(src.get("entity_id") or "").strip()
+            tgt_e = str(tgt.get("entity_id") or "").strip()
+            if not src_e or not tgt_e or src_e == tgt_e:
+                continue
+            key2 = f"{m}|{f}|{fn}|{src_e}|{tgt_e}"
+            if key2 in seen:
+                continue
+            seen.add(key2)
+
+            # Extract HA error (if present)
+            ha_err = None
+            try:
+                finds = src.get("findings") if isinstance(src.get("findings"), list) else []
+                hm = next((ff for ff in finds if isinstance(ff, dict) and str(ff.get("kind") or "") == "ha_missing"), None)
+                if hm and isinstance(hm.get("evidence"), dict):
+                    ha_err = hm.get("evidence", {}).get("error")
+            except Exception:
+                ha_err = None
+
+            out.append({
+                "measurement": m,
+                "field": f,
+                "friendly_name": fn,
+                "source": {
+                    "entity_id": src_e,
+                    "series_key": src.get("series_key"),
+                    "newest_time": (src.get("stats") or {}).get("newest_time") if isinstance(src.get("stats"), dict) else None,
+                    "score": src.get("score"),
+                    "ha_error": ha_err,
+                },
+                "target": {
+                    "entity_id": tgt_e,
+                    "series_key": tgt.get("series_key"),
+                    "newest_time": (tgt.get("stats") or {}).get("newest_time") if isinstance(tgt.get("stats"), dict) else None,
+                    "score": tgt.get("score"),
+                },
+                "hint": "Umbenennung vermutet (gleicher friendly_name; Quelle HA-fehlt)",
+            })
+
+            if len(out) >= limit:
+                break
+        if len(out) >= limit:
+            break
+
+    return jsonify({
+        "ok": True,
+        "run_id": rid,
+        "run_state": run.get("state"),
+        "candidates": out,
+        "total": len(out),
+    })
+
+
 @app.get("/api/dq/quality_run/export")
 def api_dq_quality_run_export():
     rid = str(request.args.get("id") or "").strip()

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -119,6 +119,31 @@
         </div>
       </div>
 
+      <div class="card" data-ui="dq_merge.panel_card" data-ib-pickkey="dq_merge.panel_card" title="dq.merge">
+        <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
+          <div style="font-weight:900; font-size:16px;" data-ui="dq_merge.txt_title" data-ib-pickkey="dq_merge.txt_title" title="dq.merge.title">Zusammenfuehren (Kandidaten)</div>
+          <div class="muted" id="merge_meta" data-ui="dq_merge.txt_meta" data-ib-pickkey="dq_merge.txt_meta" title="dq.merge.meta"></div>
+        </div>
+        <div class="muted">Heuristik: gleicher `friendly_name` + gleicher Messwert/Field, aber eine Seite HA-verfuegbar und die andere HA-fehlt (typisch nach Entity-ID Umbenennung).</div>
+        <div class="row" data-ui="dq_merge.panel_controls" data-ib-pickkey="dq_merge.panel_controls" title="dq.merge.controls">
+          <div style="min-width: 160px;">
+            <label>Limit</label>
+            <input id="merge_limit" type="number" min="1" max="2000" value="200" data-ui="dq_merge.input_limit" data-ib-pickkey="dq_merge.input_limit" title="dq.merge.limit" />
+          </div>
+          <button id="merge_reload" class="btn_sm" data-ui="dq_merge.btn_reload" data-ib-pickkey="dq_merge.btn_reload" title="dq.merge.reload">Aus aktivem Lauf laden</button>
+        </div>
+        <div class="table_wrap" data-ui="dq_merge.panel_table" data-ib-pickkey="dq_merge.panel_table" title="dq.merge.table">
+          <div class="table_box" style="max-height:42vh;">
+            <table id="dq_merge_tbl" data-ui="dq_merge.tbl" data-ib-pickkey="dq_merge.tbl" title="dq.merge.tbl">
+              <thead>
+                <tr><th>Friendly Name</th><th>Messwert</th><th>Quelle (HA fehlt)</th><th>Ziel (HA ok)</th><th>Aktionen</th></tr>
+              </thead>
+              <tbody id="merge_rows"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
       <div class="card" data-ui="dq_proposals.panel_card" data-ib-pickkey="dq_proposals.panel_card" title="dq.proposals">
         <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
           <div style="font-weight:900; font-size:16px;" data-ui="dq_proposals.txt_title" data-ib-pickkey="dq_proposals.txt_title" title="dq.proposals.title">Repair Proposals (Phase 2, Preview-only)</div>
@@ -269,6 +294,11 @@
       const $orphLimit = document.getElementById('orph_limit');
       const $orphReload = document.getElementById('orph_reload');
       const $orphRows = document.getElementById('orph_rows');
+
+      const $mergeMeta = document.getElementById('merge_meta');
+      const $mergeLimit = document.getElementById('merge_limit');
+      const $mergeReload = document.getElementById('merge_reload');
+      const $mergeRows = document.getElementById('merge_rows');
 
       let ACTIVE_RUN_ID = null;
       let ACTIVE_RUN = null;
@@ -655,6 +685,67 @@
         try{ if($orphMeta) $orphMeta.textContent = `Run ${String(j.run_id||'-')} | Orphans ${xs.length}`; }catch(e){}
       }
 
+      async function loadMergeCandidates(){
+        let lim = 200;
+        try{ lim = Number($mergeLimit && $mergeLimit.value ? $mergeLimit.value : 200) || 200; }catch(e){ lim = 200; }
+        lim = Math.max(1, Math.min(2000, lim));
+        const qs = new URLSearchParams();
+        qs.set('limit', String(lim));
+        if(ACTIVE_RUN_ID) qs.set('run_id', String(ACTIVE_RUN_ID));
+
+        const j = await api('./api/dq/merge_candidates?' + qs.toString());
+        const xs = Array.isArray(j.candidates) ? j.candidates : [];
+        try{ if($mergeRows) $mergeRows.innerHTML = ''; }catch(e){}
+        xs.forEach((it, idx) => {
+          const tr = document.createElement('tr');
+          const fn = String(it.friendly_name||'');
+          const meas = String(it.measurement||'') + '/' + String(it.field||'');
+          const srcE = (it.source && it.source.entity_id) ? String(it.source.entity_id) : '';
+          const tgtE = (it.target && it.target.entity_id) ? String(it.target.entity_id) : '';
+          const srcErr = (it.source && it.source.ha_error) ? String(it.source.ha_error) : '';
+
+          const tdFn = document.createElement('td'); tdFn.textContent = fn;
+          const tdM = document.createElement('td'); tdM.className='mono'; tdM.textContent = meas;
+          const tdS = document.createElement('td'); tdS.className='mono'; tdS.textContent = srcE + (srcErr ? ('\n' + srcErr) : ''); tdS.style.whiteSpace='pre-wrap';
+          const tdT = document.createElement('td'); tdT.className='mono'; tdT.textContent = tgtE;
+          const tdA = document.createElement('td'); tdA.style.whiteSpace='nowrap';
+
+          const bCopy = document.createElement('button');
+          bCopy.className='btn_sm';
+          bCopy.textContent='Copy JSON';
+          bCopy.onclick = async ()=>{
+            const payload = {
+              v: 1,
+              page: 'dq',
+              kind: 'merge_candidate',
+              measurement: String(it.measurement||''),
+              field: String(it.field||''),
+              source_entity_id: srcE,
+              target_entity_id: tgtE,
+              friendly_name: fn,
+            };
+            try{ await navigator.clipboard.writeText(JSON.stringify(payload, null, 2)); ok('In Zwischenablage kopiert.'); }
+            catch(e){ err('Clipboard Fehler.'); }
+          };
+
+          const bOpen = document.createElement('button');
+          bOpen.className='btn_sm';
+          bOpen.textContent='Open Combine';
+          bOpen.onclick = ()=>{ try{ window.location.href = './combine'; }catch(e){} };
+
+          tdA.appendChild(bCopy);
+          tdA.appendChild(bOpen);
+
+          tr.appendChild(tdFn);
+          tr.appendChild(tdM);
+          tr.appendChild(tdS);
+          tr.appendChild(tdT);
+          tr.appendChild(tdA);
+          try{ if($mergeRows) $mergeRows.appendChild(tr); }catch(e){}
+        });
+        try{ if($mergeMeta) $mergeMeta.textContent = `Run ${String(j.run_id||'-')} | Kandidaten ${xs.length}`; }catch(e){}
+      }
+
       async function pollRun(runId){
         let j;
         try{
@@ -672,6 +763,7 @@
           try{ loadProposals().catch(()=>{}); }catch(e){}
           try{ loadHAProposals().catch(()=>{}); }catch(e){}
           try{ if(st === 'done') loadOrphans().catch(()=>{}); }catch(e){}
+          try{ if(st === 'done') loadMergeCandidates().catch(()=>{}); }catch(e){}
           if(st === 'done') ok('Analyse abgeschlossen.');
           else err('Analyse Fehler: ' + String(run.error||''));
           return;
@@ -759,6 +851,8 @@
       try{ if($haReload) $haReload.onclick = ()=>{ loadHAProposals().catch(()=>{}); }; }catch(e){}
 
       try{ if($orphReload) $orphReload.onclick = ()=>{ loadOrphans().catch(e=>err('Orphans: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
+
+      try{ if($mergeReload) $mergeReload.onclick = ()=>{ loadMergeCandidates().catch(e=>err('Merge: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
 
       try{ loadHAProposals().catch(()=>{}); }catch(e){}
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.455"
+version: "1.12.456"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Neue API `/api/dq/merge_candidates`: best-effort Merge/Umbenennungs-Kandidaten aus einem DQ-Lauf.
- DQ UI (`/dq`): neue Karte "Zusammenfuehren (Kandidaten)" inkl. Copy-JSON und Link zu `Kombinieren`.

## Heuristik
- Gleicher `friendly_name` + gleicher `measurement/field`
- Quelle: HA fehlt (Finding `ha_missing`), Ziel: HA verfuegbar

## Kontext
- Teil von Epic #406 (Modul: Zusammenfuehren).

## QA
- `python3 -m py_compile influxbro/app/app.py`
- Lokaler Smoke-Test: `/dq` 200, `/api/dq/merge_candidates` 200 (ohne Runs: leere Liste).