### PR TITLE
feat(dq): open Combine with prefilled params (#406)

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - Datenpflege (DQ): neue API `/api/dq/merge_candidates` und UI-Karte "Zusammenfuehren (Kandidaten)" fuer Umbenennungs-/Merge-Hinweise (gleicher `friendly_name`, aber HA fehlt vs. HA ok). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
 
+## 1.12.457
+
+### Enhancement
+
+- Datenpflege (DQ): "Zusammenfuehren" Kandidaten koennen jetzt `Kombinieren` mit vorausgefuellten Feldern oeffnen (Query-Prefill in `/combine`). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.454
 
 ### Enhancement

--- a/influxbro/app/templates/combine.html
+++ b/influxbro/app/templates/combine.html
@@ -1070,9 +1070,52 @@
         });
       }catch(e){}
 
-      // initial suggestion lists (best-effort)
-      try{ refreshSuggestions('src').catch(()=>{}); }catch(e){}
-      try{ refreshSuggestions('tgt').catch(()=>{}); }catch(e){}
+      async function applyQueryPrefill(){
+        let qp;
+        try{ qp = new URLSearchParams(String(location && location.search ? location.search : '')); }
+        catch(e){ qp = new URLSearchParams(); }
+
+        function gv(k){ try{ return String(qp.get(k) || '').trim(); }catch(e){ return ''; } }
+        function setVal(el, v){ try{ if(el && v) el.value = v; }catch(e){} }
+
+        const dir = gv('direction');
+        if(dir === 'src_to_tgt' || dir === 'tgt_to_src'){
+          try{ if($direction) $direction.value = dir; }catch(e){}
+        }
+
+        // Common convenience keys
+        const meas = gv('measurement');
+        const field = gv('field');
+
+        const sm = gv('src_measurement') || meas;
+        const sf = gv('src_field') || field;
+        const se = gv('src_entity_id');
+        const sn = gv('src_friendly_name');
+
+        const tm = gv('tgt_measurement') || meas;
+        const tf = gv('tgt_field') || field;
+        const te = gv('tgt_entity_id');
+        const tn = gv('tgt_friendly_name');
+
+        if(sm){ setVal($srcM, sm); try{ await loadFields(sm, $srcFieldList); }catch(e){} }
+        if(sf) setVal($srcF, sf);
+        if(se) setVal($srcE, se);
+        if(sn) setVal($srcN, sn);
+
+        if(tm){ setVal($tgtM, tm); try{ await loadFields(tm, $tgtFieldList); }catch(e){} }
+        if(tf) setVal($tgtF, tf);
+        if(te) setVal($tgtE, te);
+        if(tn) setVal($tgtN, tn);
+      }
+
+      (async function init(){
+        try{ await applyQueryPrefill(); }catch(e){}
+        // initial suggestion lists (best-effort)
+        try{ refreshSuggestions('src').catch(()=>{}); }catch(e){}
+        try{ refreshSuggestions('tgt').catch(()=>{}); }catch(e){}
+        try{ _initSelectionsFromInputs(); }catch(e){}
+        try{ _renderSelTexts(); }catch(e){}
+      })();
       </script>
     </main>
   </div>

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -731,7 +731,31 @@
           const bOpen = document.createElement('button');
           bOpen.className='btn_sm';
           bOpen.textContent='Open Combine';
-          bOpen.onclick = ()=>{ try{ window.location.href = './combine'; }catch(e){} };
+          bOpen.onclick = ()=>{
+            try{
+              const qs = new URLSearchParams();
+              qs.set('direction', 'src_to_tgt');
+              qs.set('src_measurement', String(it.measurement||''));
+              qs.set('src_field', String(it.field||''));
+              qs.set('src_entity_id', srcE);
+              qs.set('src_friendly_name', fn);
+              qs.set('tgt_measurement', String(it.measurement||''));
+              qs.set('tgt_field', String(it.field||''));
+              qs.set('tgt_entity_id', tgtE);
+              qs.set('tgt_friendly_name', fn);
+              window.location.href = './combine?' + qs.toString();
+            }catch(e){
+              try{ window.location.href = './combine'; }catch(x){}
+            }
+          };
+
+          try{
+            const pk = String(it.measurement||'') + '/' + String(it.field||'') + '|' + srcE + '->' + tgtE;
+            bCopy.setAttribute('data-ui', 'dq_merge.btn_copy_json');
+            bCopy.setAttribute('data-ib-pickkey', 'dq_merge.btn_copy_json.' + pk);
+            bOpen.setAttribute('data-ui', 'dq_merge.btn_open_combine');
+            bOpen.setAttribute('data-ib-pickkey', 'dq_merge.btn_open_combine.' + pk);
+          }catch(e){}
 
           tdA.appendChild(bCopy);
           tdA.appendChild(bOpen);

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.456"
+version: "1.12.457"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- DQ Merge-Kandidaten koennen jetzt `Kombinieren` direkt mit vorausgefuellten Feldern oeffnen (Query-Prefill in `/combine`).
- `combine.html` liest Query-Parameter (`direction`, `src_*`, `tgt_*`, optional `measurement/field`) und setzt Felder inkl. Field-Listen best-effort.

## Kontext
- Teil von Epic #406 (Modul: Zusammenfuehren/Migration Workflow).

## QA
- Lokaler Smoke-Test: `/dq` 200, `/combine` 200.