### PR TITLE
feat(dq): add migration candidates for object_id entity tags (#406)

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -18,6 +18,12 @@
 
 - Datenpflege (DQ): "Zusammenfuehren" Kandidaten koennen jetzt `Kombinieren` mit vorausgefuellten Feldern oeffnen (Query-Prefill in `/combine`). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
 
+## 1.12.458
+
+### Enhancement
+
+- Datenpflege (DQ): neue API `/api/dq/migration_candidates` und UI-Karte "Migration (Kandidaten)" fuer entity_id ohne Domain (object_id), die auf eine konkrete HA Entity aufgeloest werden koennen. Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.454
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -23888,6 +23888,85 @@ def api_dq_merge_candidates():
     })
 
 
+@app.get("/api/dq/migration_candidates")
+def api_dq_migration_candidates():
+    """Suggest simple migration candidates.
+
+    Current scope (MVP): entity_id without domain (object_id only) that can be
+    resolved to a concrete HA entity_id (e.g. "kitchen_temp" -> "sensor.kitchen_temp").
+
+    This supports Epic #406 (Module: Migration).
+    """
+
+    rid = str(request.args.get("run_id") or "").strip()
+    try:
+        limit = int(request.args.get("limit") or 200)
+    except Exception:
+        limit = 200
+    limit = max(1, min(2000, limit))
+
+    if not rid:
+        for r in _dq_runs_list(50):
+            if isinstance(r, dict) and str(r.get("state") or "") == "done" and str(r.get("id") or ""):
+                rid = str(r.get("id") or "")
+                break
+
+    if not rid:
+        return jsonify({"ok": True, "run_id": None, "candidates": [], "total": 0, "error": "no dq run found"})
+
+    run = _dq_run_load(rid)
+    if not run:
+        return jsonify({"ok": False, "error": "run not found"}), 404
+
+    items = run.get("items") if isinstance(run.get("items"), list) else []
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        raw_eid = str(it.get("entity_id") or "").strip()
+        if not raw_eid:
+            continue
+        if "." in raw_eid:
+            continue
+        resolved, rerr = _resolve_ha_entity_id(raw_eid)
+        if not resolved or rerr:
+            continue
+        if resolved == raw_eid:
+            continue
+
+        m = str(it.get("measurement") or "").strip()
+        f = str(it.get("field") or "").strip()
+        fn = str(it.get("friendly_name") or "").strip()
+        if not m or not f:
+            continue
+
+        k = f"{m}|{f}|{raw_eid}|{resolved}|{fn}"
+        if k in seen:
+            continue
+        seen.add(k)
+
+        out.append({
+            "measurement": m,
+            "field": f,
+            "friendly_name": fn,
+            "source_entity_id": raw_eid,
+            "target_entity_id": resolved,
+            "hint": "entity_id ohne Domain kann auf HA Entity aufgeloest werden",
+        })
+        if len(out) >= limit:
+            break
+
+    return jsonify({
+        "ok": True,
+        "run_id": rid,
+        "run_state": run.get("state"),
+        "candidates": out,
+        "total": len(out),
+    })
+
+
 @app.get("/api/dq/quality_run/export")
 def api_dq_quality_run_export():
     rid = str(request.args.get("id") or "").strip()

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -144,6 +144,31 @@
         </div>
       </div>
 
+      <div class="card" data-ui="dq_migration.panel_card" data-ib-pickkey="dq_migration.panel_card" title="dq.migration">
+        <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
+          <div style="font-weight:900; font-size:16px;" data-ui="dq_migration.txt_title" data-ib-pickkey="dq_migration.txt_title" title="dq.migration.title">Migration (Kandidaten)</div>
+          <div class="muted" id="mig_meta" data-ui="dq_migration.txt_meta" data-ib-pickkey="dq_migration.txt_meta" title="dq.migration.meta"></div>
+        </div>
+        <div class="muted">MVP: entity_id ohne Domain (object_id) wird auf eine konkrete HA Entity aufgeloest (z.B. `kitchen_temp` -> `sensor.kitchen_temp`).</div>
+        <div class="row" data-ui="dq_migration.panel_controls" data-ib-pickkey="dq_migration.panel_controls" title="dq.migration.controls">
+          <div style="min-width: 160px;">
+            <label>Limit</label>
+            <input id="mig_limit" type="number" min="1" max="2000" value="200" data-ui="dq_migration.input_limit" data-ib-pickkey="dq_migration.input_limit" title="dq.migration.limit" />
+          </div>
+          <button id="mig_reload" class="btn_sm" data-ui="dq_migration.btn_reload" data-ib-pickkey="dq_migration.btn_reload" title="dq.migration.reload">Aus aktivem Lauf laden</button>
+        </div>
+        <div class="table_wrap" data-ui="dq_migration.panel_table" data-ib-pickkey="dq_migration.panel_table" title="dq.migration.table">
+          <div class="table_box" style="max-height:42vh;">
+            <table id="dq_mig_tbl" data-ui="dq_migration.tbl" data-ib-pickkey="dq_migration.tbl" title="dq.migration.tbl">
+              <thead>
+                <tr><th>Messwert</th><th>Quelle</th><th>Ziel</th><th>Aktionen</th></tr>
+              </thead>
+              <tbody id="mig_rows"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
       <div class="card" data-ui="dq_proposals.panel_card" data-ib-pickkey="dq_proposals.panel_card" title="dq.proposals">
         <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
           <div style="font-weight:900; font-size:16px;" data-ui="dq_proposals.txt_title" data-ib-pickkey="dq_proposals.txt_title" title="dq.proposals.title">Repair Proposals (Phase 2, Preview-only)</div>
@@ -299,6 +324,11 @@
       const $mergeLimit = document.getElementById('merge_limit');
       const $mergeReload = document.getElementById('merge_reload');
       const $mergeRows = document.getElementById('merge_rows');
+
+      const $migMeta = document.getElementById('mig_meta');
+      const $migLimit = document.getElementById('mig_limit');
+      const $migReload = document.getElementById('mig_reload');
+      const $migRows = document.getElementById('mig_rows');
 
       let ACTIVE_RUN_ID = null;
       let ACTIVE_RUN = null;
@@ -770,6 +800,66 @@
         try{ if($mergeMeta) $mergeMeta.textContent = `Run ${String(j.run_id||'-')} | Kandidaten ${xs.length}`; }catch(e){}
       }
 
+      async function loadMigrationCandidates(){
+        let lim = 200;
+        try{ lim = Number($migLimit && $migLimit.value ? $migLimit.value : 200) || 200; }catch(e){ lim = 200; }
+        lim = Math.max(1, Math.min(2000, lim));
+        const qs = new URLSearchParams();
+        qs.set('limit', String(lim));
+        if(ACTIVE_RUN_ID) qs.set('run_id', String(ACTIVE_RUN_ID));
+
+        const j = await api('./api/dq/migration_candidates?' + qs.toString());
+        const xs = Array.isArray(j.candidates) ? j.candidates : [];
+        try{ if($migRows) $migRows.innerHTML = ''; }catch(e){}
+        xs.forEach(it => {
+          const tr = document.createElement('tr');
+          const meas = String(it.measurement||'') + '/' + String(it.field||'');
+          const srcE = String(it.source_entity_id||'');
+          const tgtE = String(it.target_entity_id||'');
+          const fn = String(it.friendly_name||'');
+
+          const tdM = document.createElement('td'); tdM.className='mono'; tdM.textContent = meas;
+          const tdS = document.createElement('td'); tdS.className='mono'; tdS.textContent = srcE;
+          const tdT = document.createElement('td'); tdT.className='mono'; tdT.textContent = tgtE;
+          const tdA = document.createElement('td'); tdA.style.whiteSpace='nowrap';
+
+          const bOpen = document.createElement('button');
+          bOpen.className='btn_sm';
+          bOpen.textContent='Open Combine';
+          bOpen.onclick = ()=>{
+            try{
+              const qs = new URLSearchParams();
+              qs.set('direction', 'src_to_tgt');
+              qs.set('src_measurement', String(it.measurement||''));
+              qs.set('src_field', String(it.field||''));
+              qs.set('src_entity_id', srcE);
+              if(fn) qs.set('src_friendly_name', fn);
+              qs.set('tgt_measurement', String(it.measurement||''));
+              qs.set('tgt_field', String(it.field||''));
+              qs.set('tgt_entity_id', tgtE);
+              if(fn) qs.set('tgt_friendly_name', fn);
+              window.location.href = './combine?' + qs.toString();
+            }catch(e){
+              try{ window.location.href = './combine'; }catch(x){}
+            }
+          };
+
+          try{
+            const pk = meas + '|' + srcE + '->' + tgtE;
+            bOpen.setAttribute('data-ui', 'dq_migration.btn_open_combine');
+            bOpen.setAttribute('data-ib-pickkey', 'dq_migration.btn_open_combine.' + pk);
+          }catch(e){}
+
+          tdA.appendChild(bOpen);
+          tr.appendChild(tdM);
+          tr.appendChild(tdS);
+          tr.appendChild(tdT);
+          tr.appendChild(tdA);
+          try{ if($migRows) $migRows.appendChild(tr); }catch(e){}
+        });
+        try{ if($migMeta) $migMeta.textContent = `Run ${String(j.run_id||'-')} | Kandidaten ${xs.length}`; }catch(e){}
+      }
+
       async function pollRun(runId){
         let j;
         try{
@@ -788,6 +878,7 @@
           try{ loadHAProposals().catch(()=>{}); }catch(e){}
           try{ if(st === 'done') loadOrphans().catch(()=>{}); }catch(e){}
           try{ if(st === 'done') loadMergeCandidates().catch(()=>{}); }catch(e){}
+          try{ if(st === 'done') loadMigrationCandidates().catch(()=>{}); }catch(e){}
           if(st === 'done') ok('Analyse abgeschlossen.');
           else err('Analyse Fehler: ' + String(run.error||''));
           return;
@@ -877,6 +968,8 @@
       try{ if($orphReload) $orphReload.onclick = ()=>{ loadOrphans().catch(e=>err('Orphans: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
 
       try{ if($mergeReload) $mergeReload.onclick = ()=>{ loadMergeCandidates().catch(e=>err('Merge: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
+
+      try{ if($migReload) $migReload.onclick = ()=>{ loadMigrationCandidates().catch(e=>err('Migration: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
 
       try{ loadHAProposals().catch(()=>{}); }catch(e){}
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.457"
+version: "1.12.458"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Neue API `/api/dq/migration_candidates`: listet entity_id ohne Domain (object_id), die in HA auf eine konkrete Entity aufgeloest werden koennen.
- DQ UI (`/dq`): neue Karte "Migration (Kandidaten)" inkl. Open-Combine Action (vorausgefuellt).

## Kontext
- Teil von Epic #406 (Modul: Migration).

## QA
- `python3 -m py_compile influxbro/app/app.py`
- Lokaler Smoke-Test: `/dq` 200, `/api/dq/migration_candidates` 200 (ohne Runs: leere Liste).