### PR TITLE
feat(dq): add multi-resolution graph data and UI (#406)

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.12.459
+
+### Enhancement
+
+- Datenpflege (DQ): Multi-Resolution Graph im Detaildialog (Raw/Clean/Rollup Vergleich) via neuer API `/api/dq/multi_resolution`. Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.455
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -23967,6 +23967,208 @@ def api_dq_migration_candidates():
     })
 
 
+def _dq_points_from_bucket_v2(
+    cfg: dict[str, Any],
+    *,
+    bucket: str,
+    measurement: str,
+    field: str,
+    entity_id: str | None,
+    friendly_name: str | None,
+    start_dt: datetime,
+    stop_dt: datetime,
+    max_points: int,
+    agg_fn: str = "max",
+) -> dict[str, Any]:
+    """Fetch time/value rows from a given bucket (best-effort), with optional downsampling."""
+
+    extra = flux_tag_filter(entity_id, friendly_name)
+    dur_ms = max(0.0, (stop_dt - start_dt).total_seconds() * 1000.0)
+    every_ms = int(math.ceil(dur_ms / float(max_points))) if (dur_ms > 0 and max_points > 0) else 1
+    if every_ms < 1:
+        every_ms = 1
+
+    agg_fn = str(agg_fn or "max").strip().lower()
+    if agg_fn not in ("max", "min"):
+        agg_fn = "max"
+
+    start = _dt_to_rfc3339_utc(start_dt)
+    stop = _dt_to_rfc3339_utc(stop_dt)
+
+    agg = ""
+    mode = "raw"
+    if every_ms > 1:
+        agg = f'  |> aggregateWindow(every: {every_ms}ms, fn: {agg_fn}, createEmpty: false)\n'
+        mode = f"downsample_{agg_fn}"
+
+    q = f'''
+from(bucket: "{bucket}")
+  |> range(start: time(v: "{start}"), stop: time(v: "{stop}"))
+  |> filter(fn: (r) => r._measurement == {_flux_str(measurement)} and r._field == {_flux_str(field)}{extra})
+{agg}  |> keep(columns: ["_time","_value"])
+  |> sort(columns: ["_time"], desc: false)
+  |> limit(n: {int(max_points)})
+'''
+
+    rows: list[dict[str, Any]] = []
+    non_numeric = 0
+    with v2_client(cfg) as c:
+        qapi = c.query_api()
+        for rec in qapi.query_stream(q, org=cfg["org"]):
+            try:
+                ts = rec.get_time()
+                val = rec.get_value()
+                if not isinstance(ts, datetime):
+                    continue
+                # Normalize to numeric where possible.
+                if isinstance(val, bool):
+                    val2: float | int = 1 if val else 0
+                elif isinstance(val, (int, float)):
+                    val2 = val
+                else:
+                    non_numeric += 1
+                    continue
+                rows.append({"time": _dt_to_rfc3339_utc_ms(ts), "value": val2})
+            except Exception:
+                continue
+
+    return {
+        "bucket": bucket,
+        "measurement": measurement,
+        "field": field,
+        "rows": rows,
+        "meta": {
+            "mode": mode,
+            "every_ms": every_ms,
+            "max_points": int(max_points),
+            "agg_fn": agg_fn,
+            "non_numeric_skipped": int(non_numeric),
+            "query_language": "flux",
+            "query": q.strip(),
+        },
+    }
+
+
+def _rollup_window_key(win: str) -> str:
+    s = re.sub(r"[^0-9A-Za-z]+", "_", str(win or "")).strip("_")
+    return s or "win"
+
+
+@app.post("/api/dq/multi_resolution")
+def api_dq_multi_resolution():
+    """Read-only multi-resolution graph data (Raw/Clean/Rollup).
+
+    Part of Epic #406 (Module: Multi-Resolution Graph).
+    """
+
+    cfg = _overlay_from_yaml_if_enabled(load_cfg())
+    if int(cfg.get("influx_version", 2) or 2) != 2:
+        return jsonify({"ok": False, "error": "InfluxDB v2 required"}), 400
+    if not (cfg.get("token") and cfg.get("org") and cfg.get("bucket")):
+        return jsonify({"ok": False, "error": "InfluxDB v2 requires token, org, bucket"}), 400
+
+    body = request.get_json(force=True) or {}
+    measurement = str(body.get("measurement") or "").strip()
+    field = str(body.get("field") or "").strip()
+    entity_id = str(body.get("entity_id") or "").strip() or None
+    friendly_name = str(body.get("friendly_name") or "").strip() or None
+    if not measurement or not field:
+        return jsonify({"ok": False, "error": "measurement and field required"}), 400
+
+    # Range: explicit start/stop or derived from days.
+    start_dt = None
+    stop_dt = None
+    if body.get("start") and body.get("stop"):
+        try:
+            start_dt, stop_dt = _get_start_stop_from_payload(body)
+        except Exception as e:
+            return jsonify({"ok": False, "error": f"invalid start/stop: {e}"}), 400
+    if not start_dt or not stop_dt:
+        try:
+            days = int(body.get("days") or 30)
+        except Exception:
+            days = 30
+        days = max(1, min(3650, days))
+        stop_dt = datetime.now(timezone.utc)
+        start_dt = stop_dt - timedelta(days=days)
+
+    try:
+        max_points = int(body.get("max_points") or 1200)
+    except Exception:
+        max_points = 1200
+    max_points = max(50, min(20000, max_points))
+
+    qcfg = _quality_cfg_view(cfg)
+    raw_bucket = str(qcfg.get("raw_bucket") or cfg.get("quality_raw_bucket") or "").strip()
+    clean_bucket = str(qcfg.get("clean_bucket") or cfg.get("quality_clean_bucket") or "").strip()
+    rollup_bucket = str(qcfg.get("rollup_bucket") or cfg.get("quality_rollup_bucket") or "").strip()
+
+    out: dict[str, Any] = {
+        "ok": True,
+        "range": {"start": _dt_to_rfc3339_utc_full(start_dt), "stop": _dt_to_rfc3339_utc_full(stop_dt)},
+        "series": {"measurement": measurement, "field": field, "entity_id": entity_id, "friendly_name": friendly_name},
+        "quality": {"raw_bucket": raw_bucket, "clean_bucket": clean_bucket, "rollup_bucket": rollup_bucket, "rollups": qcfg.get("rollups")},
+        "raw": None,
+        "clean": None,
+        "rollup": {"bucket": rollup_bucket, "levels": []},
+    }
+
+    # Raw/Clean
+    try:
+        if raw_bucket:
+            out["raw"] = _dq_points_from_bucket_v2(cfg, bucket=raw_bucket, measurement=measurement, field=field, entity_id=entity_id, friendly_name=friendly_name, start_dt=start_dt, stop_dt=stop_dt, max_points=max_points, agg_fn="max")
+    except Exception as e:
+        out["raw"] = {"bucket": raw_bucket, "error": _short_influx_error(e)}
+    try:
+        if clean_bucket:
+            out["clean"] = _dq_points_from_bucket_v2(cfg, bucket=clean_bucket, measurement=measurement, field=field, entity_id=entity_id, friendly_name=friendly_name, start_dt=start_dt, stop_dt=stop_dt, max_points=max_points, agg_fn="max")
+    except Exception as e:
+        out["clean"] = {"bucket": clean_bucket, "error": _short_influx_error(e)}
+
+    # Rollup: try to pick a sensible field per window.
+    levels = qcfg.get("rollups") if isinstance(qcfg.get("rollups"), list) else []
+    for lv in levels:
+        if not isinstance(lv, dict):
+            continue
+        win = str(lv.get("window") or "").strip()
+        name = str(lv.get("name") or win).strip() or win
+        if not win:
+            continue
+        win_s = _rollup_window_key(win)
+        tried = [
+            f"{field}__mean__{win_s}",
+            f"{field}__last__{win_s}",
+            f"{field}__max__{win_s}",
+            f"{field}__min__{win_s}",
+        ]
+        chosen = None
+        chosen_res = None
+        err = None
+        if rollup_bucket:
+            for cand in tried:
+                try:
+                    res = _dq_points_from_bucket_v2(cfg, bucket=rollup_bucket, measurement=measurement, field=cand, entity_id=entity_id, friendly_name=friendly_name, start_dt=start_dt, stop_dt=stop_dt, max_points=max_points, agg_fn="max")
+                    if isinstance(res, dict) and isinstance(res.get("rows"), list) and len(res.get("rows")):
+                        chosen = cand
+                        chosen_res = res
+                        break
+                except Exception as e:
+                    err = _short_influx_error(e)
+                    continue
+
+        out["rollup"]["levels"].append({
+            "name": name,
+            "window": win,
+            "window_key": win_s,
+            "field_chosen": chosen,
+            "fields_tried": tried,
+            "data": chosen_res,
+            "error": err,
+        })
+
+    return jsonify(out)
+
+
 @app.get("/api/dq/quality_run/export")
 def api_dq_quality_run_export():
     rid = str(request.args.get("id") or "").strip()

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -30,6 +30,11 @@
     .chip.err { background:#fff0f0; border-color:#f2b0b0; color:#b00020; }
     .dlg_backdrop { position:fixed; inset:0; display:none; background: rgba(0,0,0,0.35); z-index: 12050; }
     .dlg { max-width: 980px; margin: 6vh auto; background:#fff; border-radius: 12px; padding: 14px; box-shadow: 0 16px 60px rgba(0,0,0,0.30); }
+    .dq_graph { border:1px solid #eee; border-radius:12px; padding:10px; background:#fafafa; }
+    .dq_graph canvas { width:100%; height:180px; display:block; background:#fff; border:1px solid #eee; border-radius:10px; }
+    .dq_legend { display:flex; gap:10px; flex-wrap:wrap; align-items:center; font-size:12px; margin:8px 0 10px 0; }
+    .dq_leg_item { display:inline-flex; gap:6px; align-items:center; }
+    .dq_leg_dot { width:10px; height:10px; border-radius:999px; display:inline-block; border:1px solid rgba(0,0,0,0.2); }
   </style>
 </head>
 <body>
@@ -270,6 +275,13 @@
             </div>
             <button id="dq_dlg_close" class="btn_sm" type="button" data-ui="dq_detail.btn_close" data-ib-pickkey="dq_detail.btn_close" title="dq.detail.close">Schliessen</button>
           </div>
+          <div style="margin-top:10px;">
+            <div class="dq_graph" data-ui="dq_detail.graph_wrap" data-ib-pickkey="dq_detail.graph_wrap" title="dq.detail.graph">
+              <div class="muted" id="dq_graph_meta" data-ui="dq_detail.graph_meta" data-ib-pickkey="dq_detail.graph_meta" title="dq.detail.graph.meta"></div>
+              <div class="dq_legend" id="dq_graph_legend" data-ui="dq_detail.graph_legend" data-ib-pickkey="dq_detail.graph_legend" title="dq.detail.graph.legend"></div>
+              <canvas id="dq_graph_canvas" width="920" height="180" data-ui="dq_detail.graph_canvas" data-ib-pickkey="dq_detail.graph_canvas" title="dq.detail.graph.canvas"></canvas>
+            </div>
+          </div>
           <div style="margin-top:10px;" class="mono">
             <pre id="dq_dlg_body" style="max-height:60vh; overflow:auto; border:1px solid #eee; border-radius:12px; padding:10px; background:#fafafa;" data-ui="dq_detail.pre_body" data-ib-pickkey="dq_detail.pre_body" title="dq.detail.body"></pre>
           </div>
@@ -285,6 +297,9 @@
       const $dlg = document.getElementById('dq_dlg');
       const $dlgTitle = document.getElementById('dq_dlg_title');
       const $dlgBody = document.getElementById('dq_dlg_body');
+      const $gMeta = document.getElementById('dq_graph_meta');
+      const $gLegend = document.getElementById('dq_graph_legend');
+      const $gCanvas = document.getElementById('dq_graph_canvas');
 
       const $days = document.getElementById('dq_days');
       const $limit = document.getElementById('dq_limit');
@@ -341,6 +356,175 @@
       function chip(txt, cls){ return `<span class="chip ${cls||''}">${txt}</span>`; }
       function fmtTs(iso){ try{ if(!iso) return ''; const d = new Date(String(iso)); return isFinite(d.getTime()) ? d.toLocaleString() : String(iso); }catch(e){ return String(iso||''); } }
 
+      function _isoMs(iso){ try{ const d = new Date(String(iso||'')); const ms = d.getTime(); return isFinite(ms) ? ms : null; }catch(e){ return null; } }
+
+      function _drawMultiGraph(series){
+        const c = $gCanvas;
+        if(!c) return;
+        const ctx = c.getContext('2d');
+        if(!ctx) return;
+        const w = c.width, h = c.height;
+        ctx.clearRect(0,0,w,h);
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0,0,w,h);
+
+        const sers = (series||[]).filter(s => s && Array.isArray(s.rows) && s.rows.length);
+        if(!sers.length){
+          ctx.fillStyle = '#666';
+          ctx.font = '12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+          ctx.fillText('keine Daten', 12, 22);
+          return;
+        }
+
+        let xmin = null, xmax = null, ymin = null, ymax = null;
+        sers.forEach(s => {
+          (s.rows||[]).forEach(r => {
+            const t = _isoMs(r.time);
+            const v = (r.value!==null && r.value!==undefined) ? Number(r.value) : NaN;
+            if(t===null || !isFinite(v)) return;
+            if(xmin===null || t<xmin) xmin=t;
+            if(xmax===null || t>xmax) xmax=t;
+            if(ymin===null || v<ymin) ymin=v;
+            if(ymax===null || v>ymax) ymax=v;
+          });
+        });
+        if(xmin===null || xmax===null || ymin===null || ymax===null || xmax<=xmin){
+          ctx.fillStyle = '#666';
+          ctx.font = '12px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+          ctx.fillText('keine numerischen Daten', 12, 22);
+          return;
+        }
+
+        const padL = 42, padR = 10, padT = 8, padB = 20;
+        const pw = Math.max(1, w - padL - padR);
+        const ph = Math.max(1, h - padT - padB);
+
+        // add small y padding
+        const ySpan = (ymax - ymin) || 1;
+        ymin = ymin - ySpan * 0.05;
+        ymax = ymax + ySpan * 0.05;
+
+        function xToPx(t){ return padL + ((t - xmin) / (xmax - xmin)) * pw; }
+        function yToPx(v){ return padT + (1 - ((v - ymin) / (ymax - ymin))) * ph; }
+
+        // grid
+        ctx.strokeStyle = 'rgba(0,0,0,0.06)';
+        ctx.lineWidth = 1;
+        for(let i=0;i<=4;i++){
+          const y = padT + (ph*i/4);
+          ctx.beginPath(); ctx.moveTo(padL, y); ctx.lineTo(padL+pw, y); ctx.stroke();
+        }
+        for(let i=0;i<=4;i++){
+          const x = padL + (pw*i/4);
+          ctx.beginPath(); ctx.moveTo(x, padT); ctx.lineTo(x, padT+ph); ctx.stroke();
+        }
+
+        // axes labels (minimal)
+        ctx.fillStyle = 'rgba(0,0,0,0.55)';
+        ctx.font = '11px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+        ctx.fillText(String(ymax.toFixed(2)), 6, padT + 10);
+        ctx.fillText(String(ymin.toFixed(2)), 6, padT + ph);
+
+        // series
+        sers.forEach(s => {
+          const col = String(s.color||'#1450aa');
+          ctx.strokeStyle = col;
+          ctx.lineWidth = 1.4;
+          ctx.beginPath();
+          let started = false;
+          (s.rows||[]).forEach(r => {
+            const t = _isoMs(r.time);
+            const v = (r.value!==null && r.value!==undefined) ? Number(r.value) : NaN;
+            if(t===null || !isFinite(v)) return;
+            const x = xToPx(t);
+            const y = yToPx(v);
+            if(!started){ ctx.moveTo(x,y); started=true; }
+            else ctx.lineTo(x,y);
+          });
+          ctx.stroke();
+        });
+      }
+
+      function _setLegend(items){
+        try{ if(!$gLegend) return; $gLegend.innerHTML=''; }catch(e){ return; }
+        (items||[]).forEach(it => {
+          const d = document.createElement('span');
+          d.className='dq_leg_item';
+          const dot = document.createElement('span'); dot.className='dq_leg_dot'; dot.style.background = String(it.color||'#999');
+          const txt = document.createElement('span'); txt.textContent = String(it.label||'');
+          d.appendChild(dot); d.appendChild(txt);
+          $gLegend.appendChild(d);
+        });
+      }
+
+      function _resetGraph(msg){
+        try{ if($gMeta) $gMeta.textContent = msg || ''; }catch(e){}
+        try{ _setLegend([]); }catch(e){}
+        try{ _drawMultiGraph([]); }catch(e){}
+      }
+
+      async function openDetails(it){
+        const name = String(it.label || it.series_key || 'Details');
+        try{
+          if($dlgTitle) $dlgTitle.textContent = name;
+          if($dlgBody) $dlgBody.textContent = JSON.stringify(it, null, 2);
+          _resetGraph('Multi-Resolution: lade...');
+          if($dlg) $dlg.style.display = 'block';
+        }catch(e){}
+
+        // Build range from active run params (days) as best-effort.
+        let days = 30;
+        try{ days = Number(ACTIVE_RUN && ACTIVE_RUN.params ? ACTIVE_RUN.params.days : 30) || 30; }catch(e){ days = 30; }
+        days = Math.max(1, Math.min(3650, days));
+
+        const payload = {
+          measurement: String(it.measurement||''),
+          field: String(it.field||''),
+          entity_id: String(it.entity_id||''),
+          friendly_name: String(it.friendly_name||''),
+          days: days,
+          max_points: 1200,
+        };
+
+        let j;
+        try{
+          j = await api('./api/dq/multi_resolution', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+        }catch(e){
+          try{ _resetGraph('Multi-Resolution: ' + (e && e.message ? e.message : String(e))); }catch(x){}
+          return;
+        }
+
+        const leg = [];
+        const series = [];
+
+        function addOne(label, color, block){
+          if(!block || !Array.isArray(block.rows)) return;
+          leg.push({label: label + ' (' + String(block.rows.length) + ')', color});
+          series.push({label, color, rows: block.rows});
+        }
+
+        addOne('Raw', '#999999', j.raw);
+        addOne('Clean', '#1450aa', j.clean);
+        try{
+          const levels = j.rollup && Array.isArray(j.rollup.levels) ? j.rollup.levels : [];
+          const cols = ['#0a7a28', '#9a5b00', '#7a1fa2', '#aa2e1f', '#0f7f8f'];
+          levels.forEach((lv, idx) => {
+            if(lv && lv.data && Array.isArray(lv.data.rows) && lv.data.rows.length){
+              const nm = String(lv.window||lv.name||('rollup'+idx));
+              addOne('Rollup ' + nm, cols[idx % cols.length], lv.data);
+            }
+          });
+        }catch(e){}
+
+        _setLegend(leg);
+        _drawMultiGraph(series);
+
+        try{
+          const r = j.range || {};
+          if($gMeta) $gMeta.textContent = `Multi-Resolution: ${String(r.start||'')} .. ${String(r.stop||'')}`;
+        }catch(e){}
+      }
+
       async function api(url, opts){
         const r = await fetch(url, opts);
         const j = await r.json().catch(()=>({ok:false,error:'Invalid JSON'}));
@@ -381,13 +565,7 @@
           const bDet = document.createElement('button'); bDet.className = 'btn_sm'; bDet.textContent = 'Details';
           bDet.setAttribute('data-ui','dq_results.btn_details');
           bDet.setAttribute('data-ib-pickkey','dq_results.btn_details.' + pk);
-          bDet.onclick = ()=>{
-            try{
-              if($dlgTitle) $dlgTitle.textContent = name;
-              if($dlgBody) $dlgBody.textContent = JSON.stringify(it, null, 2);
-              if($dlg) $dlg.style.display = 'block';
-            }catch(e){}
-          };
+          bDet.onclick = ()=>{ openDetails(it).catch(()=>{}); };
 
           const bDash = document.createElement('button'); bDash.className='btn_sm'; bDash.textContent = 'Dashboard';
           bDash.setAttribute('data-ui','dq_results.btn_dashboard');
@@ -469,6 +647,7 @@
           bDet.setAttribute('data-ib-pickkey','dq_proposals.btn_details.' + pk);
           bDet.onclick = ()=>{
             try{
+              _resetGraph('');
               if($dlgTitle) $dlgTitle.textContent = 'Proposal ' + pk;
               if($dlgBody) $dlgBody.textContent = JSON.stringify(p, null, 2);
               if($dlg) $dlg.style.display = 'block';
@@ -487,6 +666,7 @@
               }
               if(String(prev.type||'') === 'change_preview' && prev.payload){
                 const j2 = await api('./api/change_preview', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prev.payload)});
+                _resetGraph('');
                 if($dlgTitle) $dlgTitle.textContent = 'Preview: ' + kind;
                 if($dlgBody) $dlgBody.textContent = JSON.stringify(j2, null, 2);
                 if($dlg) $dlg.style.display = 'block';
@@ -663,7 +843,7 @@
           bDl.onclick = ()=>{ if(!patchId){ err('Kein Patch.'); return; } const a=document.createElement('a'); a.href='./api/dq/ha/patch?id=' + encodeURIComponent(patchId); a.target='_blank'; a.rel='noreferrer'; document.body.appendChild(a); a.click(); a.remove(); };
 
           const bDet = document.createElement('button'); bDet.className='btn_sm'; bDet.textContent='Details';
-          bDet.onclick = ()=>{ try{ if($dlgTitle) $dlgTitle.textContent = 'HA Proposal ' + eid; if($dlgBody) $dlgBody.textContent = JSON.stringify(p, null, 2); if($dlg) $dlg.style.display='block'; }catch(e){} };
+          bDet.onclick = ()=>{ try{ _resetGraph(''); if($dlgTitle) $dlgTitle.textContent = 'HA Proposal ' + eid; if($dlgBody) $dlgBody.textContent = JSON.stringify(p, null, 2); if($dlg) $dlg.style.display='block'; }catch(e){} };
 
           tdA.appendChild(bDet);
           tdA.appendChild(bCopy);

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.458"
+version: "1.12.459"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Neue read-only API `/api/dq/multi_resolution` liefert Multi-Resolution Punkte fuer Raw/Clean/Rollup (best-effort) inkl. Downsampling.
- DQ Detaildialog zeigt jetzt einen Multi-Resolution Graph (Raw/Clean/Rollup) fuer die ausgewaehlte Serie.

## Notes
- Rollup-Felder werden per Window-Key (z.B. 15m -> 15m) heuristisch ausgewaehlt (`<field>__mean__<win>` dann fallback auf `last/max/min`).
- Nicht-numerische Werte werden fuer den Graphen geskippt (meta: `non_numeric_skipped`).

## QA
- `python3 -m py_compile influxbro/app/app.py`
- Lokaler Smoke: `/dq` 200; `/api/dq/multi_resolution` liefert ohne Influx Config erwartetes 400.

Teil von Epic #406.