### PR TITLE
feat(dq): add debug/support panel and API (#406)

### DIFF
--- a/influxbro/CHANGELOG.md
+++ b/influxbro/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Datenpflege (DQ): Multi-Resolution Graph im Detaildialog (Raw/Clean/Rollup Vergleich) via neuer API `/api/dq/multi_resolution`. Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
 
+## 1.12.460
+
+### Enhancement
+
+- Datenpflege (DQ): Debug/Support Karte im DQ Center via neuer API `/api/dq/debug` (Info/HA/Influx/Logs/Jobs + letzte DQ Runs). Teil von Epic [#406](https://github.com/thomas682/HA-Addons/issues/406).
+
 ## 1.12.455
 
 ### Enhancement

--- a/influxbro/app/app.py
+++ b/influxbro/app/app.py
@@ -24169,6 +24169,48 @@ def api_dq_multi_resolution():
     return jsonify(out)
 
 
+@app.get("/api/dq/debug")
+def api_dq_debug():
+    """Server-side debug bundle for DQ UI (lightweight, JSON).
+
+    Part of Epic #406 (Module: Debug/Support).
+    """
+
+    cfg = _overlay_from_yaml_if_enabled(load_cfg())
+    qcfg = _quality_cfg_view(cfg)
+
+    def _j(fn):
+        try:
+            return fn().get_json()  # type: ignore[attr-defined]
+        except Exception:
+            return None
+
+    return jsonify({
+        "ok": True,
+        "now": _utc_now_iso_ms(),
+        "addon": {
+            "version": ADDON_VERSION,
+        },
+        "influx": {
+            "configured": bool(cfg.get("token") and cfg.get("org") and cfg.get("bucket")),
+            "version": cfg.get("influx_version"),
+            "bucket": cfg.get("bucket"),
+            "org": cfg.get("org"),
+        },
+        "quality": qcfg,
+        "dq": {
+            "latest_runs": _dq_runs_list(20),
+        },
+        "api": {
+            "info": _j(api_info),
+            "ha_debug": _j(api_ha_debug),
+            "influx_info": _j(api_influx_info),
+            "logs_diag": _j(api_logs_diag),
+            "jobs": _j(api_jobs),
+        },
+    })
+
+
 @app.get("/api/dq/quality_run/export")
 def api_dq_quality_run_export():
     rid = str(request.args.get("id") or "").strip()

--- a/influxbro/app/templates/dq.html
+++ b/influxbro/app/templates/dq.html
@@ -80,6 +80,19 @@
         </div>
       </div>
 
+      <div class="card" data-ui="dq_debug.panel_card" data-ib-pickkey="dq_debug.panel_card" title="dq.debug">
+        <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
+          <div style="font-weight:900; font-size:16px;" data-ui="dq_debug.txt_title" data-ib-pickkey="dq_debug.txt_title" title="dq.debug.title">Debug/Support</div>
+          <div class="muted mono" id="dbg_meta" data-ui="dq_debug.txt_meta" data-ib-pickkey="dq_debug.txt_meta" title="dq.debug.meta"></div>
+        </div>
+        <div class="row" data-ui="dq_debug.panel_controls" data-ib-pickkey="dq_debug.panel_controls" title="dq.debug.controls">
+          <button id="dbg_reload" class="btn_sm" data-ui="dq_debug.btn_reload" data-ib-pickkey="dq_debug.btn_reload" title="dq.debug.reload">Reload</button>
+        </div>
+        <div class="mono" style="margin-top:10px;">
+          <pre id="dbg_out" style="max-height:34vh; overflow:auto; border:1px solid #eee; border-radius:12px; padding:10px; background:#fafafa;" data-ui="dq_debug.pre_out" data-ib-pickkey="dq_debug.pre_out" title="dq.debug.out"></pre>
+        </div>
+      </div>
+
       <div class="card" data-ui="dq_results.panel_card" data-ib-pickkey="dq_results.panel_card" title="dq.results">
         <div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:baseline;">
           <div style="font-weight:900; font-size:16px;" data-ui="dq_results.txt_title" data-ib-pickkey="dq_results.txt_title" title="dq.results.title">Uebersicht</div>
@@ -309,6 +322,10 @@
       const $export = document.getElementById('dq_export');
       const $support = document.getElementById('dq_support');
       const $dlgClose = document.getElementById('dq_dlg_close');
+
+      const $dbgMeta = document.getElementById('dbg_meta');
+      const $dbgReload = document.getElementById('dbg_reload');
+      const $dbgOut = document.getElementById('dbg_out');
 
       const $propMeta = document.getElementById('prop_meta');
       const $propGen = document.getElementById('dq_props_gen');
@@ -1040,6 +1057,23 @@
         try{ if($migMeta) $migMeta.textContent = `Run ${String(j.run_id||'-')} | Kandidaten ${xs.length}`; }catch(e){}
       }
 
+      async function loadDebug(){
+        let j;
+        try{ j = await api('./api/dq/debug'); }
+        catch(e){
+          try{ if($dbgMeta) $dbgMeta.textContent = 'Fehler: ' + (e && e.message ? e.message : String(e)); }catch(x){}
+          try{ if($dbgOut) $dbgOut.textContent = ''; }catch(x){}
+          return;
+        }
+        try{
+          const v = j && j.addon ? String((j.addon.version)||'') : '';
+          const infl = j && j.influx ? j.influx : null;
+          const inflOk = infl ? (String(!!infl.configured)) : '';
+          if($dbgMeta) $dbgMeta.textContent = `v=${v} influx_configured=${inflOk}`;
+        }catch(e){}
+        try{ if($dbgOut) $dbgOut.textContent = JSON.stringify(j, null, 2); }catch(e){}
+      }
+
       async function pollRun(runId){
         let j;
         try{
@@ -1150,6 +1184,10 @@
       try{ if($mergeReload) $mergeReload.onclick = ()=>{ loadMergeCandidates().catch(e=>err('Merge: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
 
       try{ if($migReload) $migReload.onclick = ()=>{ loadMigrationCandidates().catch(e=>err('Migration: ' + (e && e.message ? e.message : String(e)))); }; }catch(e){}
+
+      try{ if($dbgReload) $dbgReload.onclick = ()=>{ loadDebug().catch(()=>{}); }; }catch(e){}
+
+      try{ loadDebug().catch(()=>{}); }catch(e){}
 
       try{ loadHAProposals().catch(()=>{}); }catch(e){}
 

--- a/influxbro/config.yaml
+++ b/influxbro/config.yaml
@@ -2,7 +2,7 @@ name: InfluxBro
 description: >-
   Browse InfluxDB (table + mini graph), configure in UI, entity_id/friendly_name
   filters, and optionally delete ranges
-version: "1.12.459"
+version: "1.12.460"
 slug: influxbro
 url: "https://github.com/thomas682/HA-Addons/tree/main/influxbro"
 


### PR DESCRIPTION
## Summary
- Neue API `/api/dq/debug`: liefert kompaktes Debug-JSON fuer DQ (info/ha/influx/logs/jobs + letzte DQ runs).
- DQ UI (`/dq`): neue Karte "Debug/Support" mit Reload und JSON-Ausgabe.

## QA
- `python3 -m py_compile influxbro/app/app.py`
- Lokaler Smoke: `/api/dq/debug` 200.

Teil von Epic #406.